### PR TITLE
TLV work

### DIFF
--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -15,7 +15,8 @@ public class TLVDecoder {
 
     private final Set<Integer> expandTags = new HashSet<>();
 
-    public TLVDecoder() { }
+    public TLVDecoder() {
+    }
 
     public void addExpandTag(byte[] tag) throws TLVException {
         expandTags.add(TLVUtils.tagToInt(tag));
@@ -89,7 +90,7 @@ public class TLVDecoder {
             helper(value, 0, tags);
         } else {
             tags.add(new TLV(tag, lengthEncoded, value));
-            if(offset + length == input.length) {
+            if (offset + length == input.length) {
                 // We are finished
             } else {
                 helper(input, offset + length, tags);

--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -88,6 +88,10 @@ public class TLVDecoder {
                 throw new TLVException("Expand tag " + Hex.toHexString(tag) + " is invalid, exceeds data length");
             }
             helper(value, 0, tags);
+            if (offset + length < input.length) {
+                // There are more tags after the expander tag.
+                helper(input, offset + length, tags);
+            }
         } else {
             tags.add(new TLV(tag, lengthEncoded, value));
             if (offset + length == input.length) {

--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -32,7 +32,7 @@ public class TLVDecoder {
     private void helper(byte[] input, int offset, List<TLV> tags) throws TLVException {
 
         // Parse tag
-        byte[] tag = new byte[]{input[0]};
+        byte[] tag = new byte[]{input[offset]};
         if ((input[offset] & 0x1f) == 0x1f) {
             /*
              * If first byte of a tag has lowest 5 bits set, it's a multi-byte

--- a/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
+++ b/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
@@ -55,7 +55,7 @@ public class TLVDecoderTest {
     public void testExpandedTagWithMoreTagsAfter() throws Exception {
         TLVDecoder dec = new TLVDecoder();
         dec.addExpandTag(Hex.hexToByteArray("9A"));
-        List<TLV> decodedTags = dec.decode(Hex.hexToByteArray("9A0E9F2602AABB9F2702CCDD5F200101"));
+        List<TLV> decodedTags = dec.decode(Hex.hexToByteArray("9A0A9F2602AABB9F2702AABB5F200101"));
         Assert.assertEquals(3, decodedTags.size());
     }
 

--- a/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
+++ b/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
@@ -27,6 +27,49 @@ public class TLVDecoderTest {
     }
 
     @Test
+    public void testMultiTags() throws Exception {
+        byte[] tlvData = Hex.hexToByteArray("E003010203E103040506");
+        TLVDecoder dec = new TLVDecoder();
+        List<TLV> tlvs = dec.decode(tlvData);
+        Assert.assertEquals(2, tlvs.size());
+    }
+
+    @Test
+    public void testMultiTagsWithExpander() throws Exception {
+        byte[] tlvData = Hex.hexToByteArray("E50AE003010203E103040506");
+        TLVDecoder dec = new TLVDecoder();
+        dec.addExpandTag(Hex.hexToByteArray("E5"));
+        List<TLV> tlvs = dec.decode(tlvData);
+        Assert.assertEquals(2, tlvs.size());
+    }
+
+    @Test(expected = TLVException.class)
+    public void testMultiTagsWithExpanderWithWrongExpanderLength() throws Exception {
+        byte[] tlvData = Hex.hexToByteArray("E50BE003010203E103040506");
+        TLVDecoder dec = new TLVDecoder();
+        dec.addExpandTag(Hex.hexToByteArray("E5"));
+        dec.decode(tlvData);
+    }
+
+    @Test(expected = TLVException.class)
+    public void testMultiTagsWithGarbageEnd() throws Exception {
+        byte[] tlvData = Hex.hexToByteArray("E003010203E10304050690");
+        TLVDecoder dec = new TLVDecoder();
+        List<TLV> tlvs = dec.decode(tlvData);
+        Assert.assertEquals(2, tlvs.size());
+    }
+
+    @Test
+    public void testNestedExpands() throws Exception {
+        byte[] tlvData = Hex.hexToByteArray("E105E203E30101");
+        TLVDecoder dec = new TLVDecoder();
+        dec.addExpandTag(Hex.hexToByteArray("E1"));
+        dec.addExpandTag(Hex.hexToByteArray("E2"));
+        List<TLV> tlvs = dec.decode(tlvData);
+        Assert.assertEquals(1, tlvs.size());
+    }
+
+    @Test
     public void test5ByteLength() throws Exception {
 
         byte[] tlvData = Hex.hexToByteArray("4F8400000005AABBCCDDEE");

--- a/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
+++ b/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
@@ -51,6 +51,14 @@ public class TLVDecoderTest {
         dec.decode(tlvData);
     }
 
+    @Test
+    public void testExpandedTagWithMoreTagsAfter() throws Exception {
+        TLVDecoder dec = new TLVDecoder();
+        dec.addExpandTag(Hex.hexToByteArray("9A"));
+        List<TLV> decodedTags = dec.decode(Hex.hexToByteArray("9A0E9F2602AABB9F2702CCDD5F200101"));
+        Assert.assertEquals(3, decodedTags.size());
+    }
+
     @Test(expected = TLVException.class)
     public void testMultiTagsWithGarbageEnd() throws Exception {
         byte[] tlvData = Hex.hexToByteArray("E003010203E10304050690");


### PR DESCRIPTION
Fixed big blooper with multitag parsing.
Stricter parsing, more exception prone on malformed data.
Bunch of tests for multitag and expander tags.

Ping @staffanjonsson for another eye on this.