### PR TITLE
UUIDFactory: Fixes create alternate

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/UUIDFactory.java
+++ b/izettle-java/src/main/java/com/izettle/java/UUIDFactory.java
@@ -41,6 +41,10 @@ public final class UUIDFactory {
      * is based on the supplied one. This method is guaranteed to return a different UUID than the one supplied,
      * but done in a deterministic fashion (same value will be returned every time for each input value) and with the
      * same guarantee that the result is sufficiently unique to be used as a UUID.
+     * Note, that for a time based UUID (type 1), the original time information will be kept intact. This might be
+     * surprising, but there are really no logical alternatives (except for not allowing to create alternatives for this
+     * type of UUID). As a consequence, the time information within the resulting UUID should not be used as a
+     * substitute for information about when an event actually happened.
      * @param uuid The original UUID.
      * @return A new UUID that is based on the original UUID.
      */
@@ -53,6 +57,10 @@ public final class UUIDFactory {
      * on the supplied one. This method is guaranteed to return a different UUID than the one supplied, but done in a
      * deterministic fashion (same value will be returned every time for each input value) and with the same guarantee
      * that the result is sufficiently unique to be used as a UUID.
+     * Note, that for a time based UUID (type 1), the original time information will be kept intact. This might be
+     * surprising, but there are really no logical alternatives (except for not allowing to create alternatives for this
+     * type of UUID). As a consequence, the time information within the resulting UUID should not be used as a
+     * substitute for information about when an event actually happened.
      * @param uuid The original UUID.
      * @param mask Seed value to be used when producing the alternative. This value will be xor:ed
      *             with the original bytes to produce the alternative.

--- a/izettle-java/src/test/java/com/izettle/java/UUIDFactoryTest.java
+++ b/izettle-java/src/test/java/com/izettle/java/UUIDFactoryTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import com.izettle.java.testutils.UUIDUtils;
 import java.nio.ByteBuffer;
 import java.util.Date;
+import java.util.Random;
 import java.util.UUID;
 import org.junit.Test;
 
@@ -79,6 +80,46 @@ public class UUIDFactoryTest {
         String alternativeUUID = UUIDFactory.createAlternative(uuid);
 
         assertOnAlternativeUUID(uuid, alternativeUUID);
+    }
+
+    @Test
+    public void itShouldBeReflectiveBetweenLongsAndBytes() {
+        Random rnd = new Random();
+        for(int i = 0; i < 1000; i++){
+            long l = rnd.nextLong();
+            assertEquals(l, UUIDFactory.bytesToLong(UUIDFactory.longToBytes(l)));
+        }
+    }
+
+    @Test
+    public void itShouldBeReflectiveBetweenB64AndUUID() {
+        for(int i = 0; i < 1000; i++){
+            UUID uuid = UUID.randomUUID();
+            assertEquals(uuid, UUIDFactory.fromBase64String(UUIDFactory.toBase64String(uuid)));
+        }
+    }
+
+    @Test
+    public void alternativeVersionOfUUIDShouldPreserveVersionBitAndTimestampForTimeUUID() {
+        String uuidString = UUIDFactory.createUUID1AsString();
+        UUID uuid = UUIDFactory.fromBase64String(uuidString);
+        String alt = UUIDFactory.createAlternative(uuidString);
+        UUID altUuid = UUIDFactory.fromBase64String(alt);
+        assertEquals(UUIDFactory.VERSION_TIME_BASED, uuid.version());
+        assertEquals(UUIDFactory.VERSION_TIME_BASED, altUuid.version());
+        assertNotEquals(uuid, alt);
+        assertEquals(uuid.timestamp(), altUuid.timestamp());
+    }
+
+    @Test
+    public void alternativeVersionOfUUIDShouldPreserveVersionBitForRandomUUID() {
+        String uuidString = UUIDFactory.createUUID4AsString();
+        UUID uuid = UUIDFactory.fromBase64String(uuidString);
+        String alt = UUIDFactory.createAlternative(uuidString);
+        UUID altUuid = UUIDFactory.fromBase64String(alt);
+        assertEquals(UUIDFactory.VERSION_RANDOM, uuid.version());
+        assertEquals(UUIDFactory.VERSION_RANDOM, altUuid.version());
+        assertNotEquals(uuid, alt);
     }
 
     @Test


### PR DESCRIPTION
Previously the method `createAlternative` mangled each byte in the UUID
without taking the structure of the data into consideration. The effect
of this was that the resulting alternative was not always a proper UUID
according to the standard.

This change does mainly two things:
* Make sure that `version` and `variant` is always preserved when
  creating an alternative.
* For time-based UUID, the entire MSB is preserved as we want the
  alternative to have the same time information as the original: only
  the LSB is altered

ping @erikryverling , as you've been involved in the UUID stuff lately.

related to https://github.com/iZettle/izettle-planet/pull/321