### PR TITLE
UUIDFactory: Fix for not preserving variant when createAlternative

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/UUIDFactory.java
+++ b/izettle-java/src/main/java/com/izettle/java/UUIDFactory.java
@@ -91,7 +91,7 @@ public final class UUIDFactory {
         //We can always change the least significant bits
         final byte[] lsBytes = longToBytes(mask(originalUuid.getLeastSignificantBits(), mask));
         lsBytes[0] &= 0x3f;  //clear variant
-        lsBytes[0] |= originalVariant << 4;
+        lsBytes[0] |= originalVariant << 6;
         final long lsb = bytesToLong(lsBytes);
         return toBase64String(new UUID(msb, lsb));
     }

--- a/izettle-java/src/test/java/com/izettle/java/UUIDFactoryTest.java
+++ b/izettle-java/src/test/java/com/izettle/java/UUIDFactoryTest.java
@@ -149,6 +149,42 @@ public class UUIDFactoryTest {
         assertTrue(uuidDate.compareTo(recentCurrentDate) > 0);
     }
 
+    @Test
+    public void shouldCreateAlternativeForVersion4InTheSameWayAsBefore() {
+        for(int i = 0; i < 1000; i++) {
+            String uuidString = UUIDFactory.createUUID4AsString();
+            String oldAlternative = createAlternative_oldVersion(uuidString);
+            String newAlternative = UUIDFactory.createAlternative(uuidString);
+            UUID oldAltUUID = UUIDFactory.fromBase64String(oldAlternative);
+            UUID newAltUUID = UUIDFactory.fromBase64String(newAlternative);
+            assertEquals(oldAltUUID.version(), newAltUUID.version());
+            assertEquals(oldAltUUID.variant(), newAltUUID.variant());
+            assertEquals(oldAlternative, newAlternative);
+        }
+        for(int i = 0; i < 1000; i++){
+            String uuidString = UUIDFactory.createUUID1AsString();
+            UUID originalUUID = UUIDFactory.fromBase64String(uuidString);
+            String alternative = UUIDFactory.createAlternative(uuidString);
+            UUID alternativeUUID = UUIDFactory.fromBase64String(alternative);
+            assertEquals(originalUUID.variant(), alternativeUUID.variant());
+            assertEquals(originalUUID.version(), alternativeUUID.version());
+        }
+    }
+
+    /*
+     * This is the old version of how we did create alternative. It was originally in the UUIDFactory, but moved here as
+     * it's not used anymore, but needs to be used
+     * for verifying that we haven't broken anything
+    */
+    private static String createAlternative_oldVersion(String uuid) {
+        final byte[] mask = new byte[]{(byte) 0x01};
+        byte[] bytes = UUIDFactory.uuidToByteArray(uuid);
+        for (int i = 0; i < bytes.length; ++i) {
+            bytes[i] ^= mask[i % mask.length];
+        }
+        return Base64.byteArrToB64String(bytes);
+    }
+
     private void assertOnBase64String(String base64EncodedString) {
         assertNotNull(base64EncodedString);
         assertFalse(base64EncodedString.isEmpty());


### PR DESCRIPTION
Discovered when creating a test for backwards compatibility

Nice catch @mikaellothman ! This is all yours :) 

needs to be released and included in our other systems pronto before their release.