### PR TITLE
messaging: Extract body of QueueProcessingThread into QueueProcessingRunnable

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueProcessingRunnable.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueProcessingRunnable.java
@@ -1,0 +1,73 @@
+package com.izettle.messaging;
+
+import static java.lang.Thread.sleep;
+
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of a runnable that keeps on polling a message queue until explicitly stopped.
+ */
+public class QueueProcessingRunnable implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(QueueProcessingRunnable.class);
+    private final String name;
+    private final MessageQueueProcessor queueProcessor;
+    private volatile boolean alive;
+    private volatile Thread executingThread;
+
+    public QueueProcessingRunnable(MessageQueueProcessor queueProcessor) {
+        this.name = queueProcessor.getName();
+        this.queueProcessor = queueProcessor;
+    }
+
+    @Override
+    public void run() {
+
+        LOG.info(String.format("Message queue processor %s started.", name));
+        executingThread = Thread.currentThread();
+        alive = true;
+
+        while (isAlive()) {
+            try {
+                queueProcessor.poll();
+            } catch (MessagingException e) {
+                LOG.error(String.format("Message queue processor %s failed to poll for new messages.", name), e);
+                if (!isAlive()) {
+                    break;
+                }
+                try {
+                    sleep(TimeUnit.MINUTES.toMillis(1));
+                } catch (InterruptedException e1) {
+                    break;
+                }
+            }
+        }
+        alive = false;
+        executingThread = null;
+
+        LOG.info(String.format("Message queue processor %s stopped.", name));
+    }
+
+    private boolean isAlive() {
+        if (!alive) {
+            return false;
+        }
+        final Thread thread = this.executingThread;
+        if (thread != null && thread.isInterrupted()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Makes the polling loop stop some time in the future.
+     */
+    public void shutdown() {
+        alive = false;
+        final Thread thread = this.executingThread;
+        if (thread != null) {
+            thread.interrupt();
+        }
+    }
+}

--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueProcessingThread.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueProcessingThread.java
@@ -1,6 +1,5 @@
 package com.izettle.messaging;
 
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,41 +8,23 @@ import org.slf4j.LoggerFactory;
  */
 public class QueueProcessingThread extends Thread {
     private static final Logger LOG = LoggerFactory.getLogger(QueueProcessingThread.class);
-    private final String name;
-    private final MessageQueueProcessor queueProcessor;
+    private final QueueProcessingRunnable runnable;
 
     public QueueProcessingThread(MessageQueueProcessor queueProcessor) {
         super(queueProcessor.getName());
-        this.name = queueProcessor.getName();
-        this.queueProcessor = queueProcessor;
+        this.runnable = new QueueProcessingRunnable(queueProcessor);
     }
 
     @Override
     public void run() {
-
-        LOG.info(String.format("Message queue processor %s started.", name));
-
-        while (!isInterrupted()) {
-            try {
-                queueProcessor.poll();
-            } catch (MessagingException e) {
-                LOG.error(String.format("Message queue processor %s failed to poll for new messages.", name), e);
-                try {
-                    sleep(TimeUnit.MINUTES.toMillis(1));
-                } catch (InterruptedException e1) {
-                    break;
-                }
-            }
-        }
-
-        LOG.info(String.format("Message queue processor %s stopped.", name));
+        runnable.run();
     }
 
     /**
      * Stops the polling thread and waits for last message completion before returning to caller
      */
     public void shutdown() {
-        interrupt();
+        runnable.shutdown();
         try {
             join();
         } catch (InterruptedException ignored) {


### PR DESCRIPTION
* Extracts the body of the `run()` method from `QueueProcessingThread` into a new class `QueueProcessingRunnable` that only implements `Runnable` (and not `Thread`).
* This would be useful when running a queue poller in an environment where the caller would not want to create the actual thread manually, such as in a java EE environment.