### PR TITLE
Upgrades AWS to v1.9.30 from v1.6.4

### DIFF
--- a/izettle-cassandra/pom.xml
+++ b/izettle-cassandra/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
             <version>${aws.version}</version>
         </dependency>
         <dependency>

--- a/izettle-messaging/pom.xml
+++ b/izettle-messaging/pom.xml
@@ -23,7 +23,12 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+            <version>${aws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
             <version>${aws.version}</version>
         </dependency>
         <dependency>

--- a/izettle-messaging/src/main/java/com/izettle/messaging/MessagingException.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/MessagingException.java
@@ -24,10 +24,10 @@ public class MessagingException extends Exception {
 
     private static String buildAmazonClientExceptionMessage(AmazonClientException ace) {
         StringBuilder sb = new StringBuilder();
-        sb.append("Caught an AmazonClientException, which means the client encountered " +
+        sb.append(" Caught an AmazonClientException, which means the client encountered " +
                 "a serious internal problem while trying to communicate with SQS, such as not " +
                 "being able to access the network.");
-        sb.append("Error Message: ").append(ace.getMessage());
+        sb.append(" Error Message: ").append(ace.getMessage());
         return sb.toString();
     }
 

--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueProcessor.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueProcessor.java
@@ -2,6 +2,7 @@ package com.izettle.messaging;
 
 import static com.izettle.java.ValueChecks.empty;
 
+import com.amazonaws.AbortedException;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.DeleteMessageRequest;
@@ -9,6 +10,7 @@ import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.izettle.messaging.handler.MessageHandler;
 import com.izettle.messaging.handler.MessageHandlerForSingleMessageType;
+import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,9 +104,11 @@ public class QueueProcessor implements MessageQueueProcessor {
             messageRequest.setWaitTimeSeconds(MESSAGE_WAIT_SECONDS);
         }
         List<Message> messages;
-
         try {
             messages = amazonSQS.receiveMessage(messageRequest).getMessages();
+        } catch (AbortedException e) {
+            LOG.info("Client abort.");
+            messages = Collections.emptyList();
         } catch (AmazonClientException e) {
             throw new MessagingException("Failed to poll message queue.", e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <astyanax.version>1.56.37</astyanax.version>
-        <aws.version>1.6.4</aws.version>
+        <aws.version>1.9.28.1</aws.version>
         <bouncycastle.version>1.47</bouncycastle.version>
         <jackson.version>2.2.3</jackson.version>
         <slf4j.version>1.7.2</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <astyanax.version>1.56.37</astyanax.version>
-        <aws.version>1.9.28.1</aws.version>
+        <aws.version>1.9.30</aws.version>
         <bouncycastle.version>1.47</bouncycastle.version>
         <jackson.version>2.2.3</jackson.version>
         <slf4j.version>1.7.2</slf4j.version>


### PR DESCRIPTION
For awhile now Amazon have split their SDK into separate jar's per
service, so we are picking only the services we use here (SNS, SQS and
EC2).

For your consideration:
@oskarwiksten, @mxns, @xiaodong-izettle and @mikaellothman