### PR TITLE
Find system TimeZoneId

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
+++ b/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
@@ -624,6 +624,7 @@ public enum TimeZoneId {
     PACIFIC_TONGATAPU("Pacific/Tongatapu"),
     ETC_GMT_MINUS14("Etc/GMT-14"),
     PACIFIC_KIRITIMATI("Pacific/Kiritimati");
+
     private final String stringId;
 
     private TimeZoneId(String stringId) {
@@ -632,5 +633,18 @@ public enum TimeZoneId {
 
     public TimeZone getTimeZone() {
         return TimeZone.getTimeZone(this.stringId);
+    }
+
+    public static TimeZoneId getByTimeZone(TimeZone timeZone) {
+        for (TimeZoneId timeZoneId : values()) {
+            if (timeZoneId.stringId.equals(timeZone.getID())) {
+                return timeZoneId;
+            }
+        }
+        throw new IllegalArgumentException("No TimeZoneId with id " + timeZone.getID());
+    }
+
+    public static TimeZoneId systemTimeZoneId() {
+        return getByTimeZone(TimeZone.getDefault());
     }
 }


### PR DESCRIPTION
ping @aaanders @adamvoncorswant 

I wonder if we have this logic somewhere else already?

I'm adding this because in prod we use `UTC` and in DEV we use `Europe/Stockholm`. 
When we use hibernate to fetch a `java.util.Date` it automatically parses it with the system's timezone, so we need to make sure that all the logic performed over that date uses the same timezone.

This is timezones though, so my head feels like a spaghetti carbonara by now. I might be overkilling it.