### PR TITLE
Track 1 parser

### DIFF
--- a/izettle-emv/src/main/java/com/izettle/msr/Track1Data.java
+++ b/izettle-emv/src/main/java/com/izettle/msr/Track1Data.java
@@ -1,0 +1,42 @@
+package com.izettle.msr;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by fidde on 02/06/15.
+ */
+public class Track1Data {
+
+    private final static Pattern P = Pattern.compile(
+        ""
+            + "%([A-Z])([0-9]{1,19})\\^([^\\^]{2,26})\\^([0-9]{4}|\\^)"
+            + "([0-9]{3}|\\^)([^\\?]+)\\?.*"
+    );
+
+    public String formatCode;
+    public String pan;
+    public String name;
+    public String expirationDate;
+    public String serviceCode;
+    public String discretionaryData;
+    public String raw;
+
+    public static Track1Data parse(String ascii) {
+
+        Track1Data out = new Track1Data();
+        out.raw = ascii;
+
+        Matcher m = P.matcher(ascii);
+        if (m.matches()) {
+            out.formatCode = m.group(1);
+            out.pan = m.group(2);
+            out.name = m.group(3);
+            out.expirationDate = m.group(4);
+            out.serviceCode = m.group(5);
+            out.discretionaryData = m.group(6);
+        }
+        return out;
+    }
+
+}

--- a/izettle-emv/src/main/java/com/izettle/msr/Track1Data.java
+++ b/izettle-emv/src/main/java/com/izettle/msr/Track1Data.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
  */
 public class Track1Data {
 
-    private final static Pattern P = Pattern.compile(
+    private static final Pattern P = Pattern.compile(
         ""
             + "%([A-Z])([0-9]{1,19})\\^([^\\^]{2,26})\\^([0-9]{4}|\\^)"
             + "([0-9]{3}|\\^)([^\\?]+)\\?.*"

--- a/izettle-emv/src/test/java/com/izettle/msr/Track1DataTest.java
+++ b/izettle-emv/src/test/java/com/izettle/msr/Track1DataTest.java
@@ -1,0 +1,75 @@
+package com.izettle.msr;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by fidde on 02/06/15.
+ */
+public class Track1DataTest {
+
+    @Test
+    public void testSomeMTIPCards() {
+
+        String t1 = null;
+        Track1Data t1d = null;
+
+        t1 = "%B5413330056003529^CUST IMP MC 352/^14122059900909900000099909909969929990400?";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("CUST IMP MC 352/", t1d.name);
+        Assert.assertEquals("205", t1d.serviceCode);
+
+        t1 = "%B5413330056003511^CUST IMP MC 351/^1412101067750500?";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("CUST IMP MC 351/", t1d.name);
+        Assert.assertEquals("101", t1d.serviceCode);
+        Assert.assertEquals("5413330056003511", t1d.pan);
+
+        t1 = "%B5413330056003560^CUST IMP MC 356/ 1^141210100000170099909919769790?";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("CUST IMP MC 356/ 1", t1d.name);
+        Assert.assertEquals("101", t1d.serviceCode);
+        Assert.assertEquals("5413330056003560", t1d.pan);
+
+        t1 = "%B5413330057004062^CUST IMP MC 406/^142512201020730270?";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("CUST IMP MC 406/", t1d.name);
+        Assert.assertEquals("1425", t1d.expirationDate);
+    }
+
+    @Test
+    public void testSomeADVTCards() {
+
+        String t1 = null;
+        Track1Data t1d = null;
+
+        t1 = "%B4761739001010119^VISA ACQUIRER TEST CARD 01^15122011758900540000000?";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("VISA ACQUIRER TEST CARD 01", t1d.name);
+        Assert.assertEquals("201", t1d.serviceCode);
+
+        t1 = "%B4761739001010036^VISA ACQUIRER TEST CARD 03^15122011184400799000000?";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("VISA ACQUIRER TEST CARD 03", t1d.name);
+        Assert.assertEquals("1512", t1d.expirationDate);
+
+        t1 = "%B4761739001010010^VISA ACQUIRER TEST CARD 05^15122011143800575000000?";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("VISA ACQUIRER TEST CARD 05", t1d.name);
+        Assert.assertEquals("1143800575000000", t1d.discretionaryData);
+    }
+
+    @Test
+    public void testSomeRandomCards() {
+
+        String t1 = null;
+        Track1Data t1d = null;
+
+        t1 = "%B1234123412341234^fidde was here^030510100000019301000000877000000?;this data matters not";
+        t1d = Track1Data.parse(t1);
+        Assert.assertEquals("fidde was here", t1d.name);
+        Assert.assertEquals("101", t1d.serviceCode);
+        Assert.assertEquals("B", t1d.formatCode);
+    }
+
+}


### PR DESCRIPTION
Basic track 1 parser that at least works for the MTIP and ADVT cards - will do some more testing with weird cards. Mostly to get the cardholder name for the last-used-email hashing, ref https://github.com/iZettle/izettle-planet/issues/138

Ping @linnie @staffanjonsson 