### PR TITLE
Messaging: Avoids NPE on newly created queue setup

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/AmazonSNSSubscriptionSetup.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/AmazonSNSSubscriptionSetup.java
@@ -102,7 +102,13 @@ public class AmazonSNSSubscriptionSetup {
 
         String policyJson = queueAttributesResult.getAttributes().get(QueueAttributeName.Policy.name());
 
-        List<Statement> statements = new ArrayList<>(Policy.fromJson(policyJson).getStatements());
+        final List<Statement> statements;
+        if (policyJson != null) {
+            statements = new ArrayList<>(Policy.fromJson(policyJson).getStatements());
+        } else {
+            // no policies yet exist
+            statements = new ArrayList<>();
+        }
 
         statements.add(
             new Statement(Statement.Effect.Allow)


### PR DESCRIPTION
- A new queue has no policies, avoid NPE parsing nothing

  On queue setup we attempt to append new policies to a queue. If the
  queue is new it won't have any existing policies so we can start with
  an empty list instead of attempting to parse policies that aren't
  there.

  This change avoids this exception:

    Exception in thread "main" java.lang.IllegalArgumentException: JSON string cannot be null
    at com.amazonaws.auth.policy.internal.JsonPolicyReader.createPolicyFromJsonString(JsonPolicyReader.java:66)
    at com.amazonaws.auth.policy.Policy.fromJson(Policy.java:229)
    at com.izettle.messaging.AmazonSNSSubscriptionSetup.allowSQSQueueToReceiveMessagesFromSNSTopic(AmazonSNSSubscriptionSetup.java:105)
    at com.izettle.messaging.AmazonSNSSubscriptionSetup.subscribeSQSQueueToSNSTopic(AmazonSNSSubscriptionSetup.java:56)

Ping @xiaodong-izettle and @oskarwiksten