### PR TITLE
UUIDFactory: Add method for parsing both string versions

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/UUIDFactory.java
+++ b/izettle-java/src/main/java/com/izettle/java/UUIDFactory.java
@@ -1,5 +1,7 @@
 package com.izettle.java;
 
+import static com.izettle.java.ValueChecks.empty;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.UUID;
@@ -173,7 +175,25 @@ public final class UUIDFactory {
         return buffer;
     }
 
-    public static UUID fromBase64String(String b64) {
+    /**
+     * Will try to parse a java.util.UUID object from the provided string. The argument may be either base64
+     * encoded with the length 22, or the standard notation xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx with a length of 36.
+     * Any other length of the value will throw an IllegalArgumentException
+     * @param value the value to parse
+     * @return the parsed UUID object
+     * @throws IllegalArgumentException if the provided argument is not parseable.
+     */
+    public static UUID parse(String value) {
+        if (empty(value)) {
+            throw new IllegalArgumentException("Cannot parse a UUID from an empty string");
+        }
+        if (value.length() == 22) {
+            return fromBase64String(value);
+        }
+        return UUID.fromString(value);
+    }
+
+    static UUID fromBase64String(String b64) {
         if (b64 == null || b64.length() != 22) {
             throw new IllegalArgumentException("Argument b64 string must be defined and have a length of exactly 22");
         }

--- a/izettle-java/src/test/java/com/izettle/java/UUIDFactoryTest.java
+++ b/izettle-java/src/test/java/com/izettle/java/UUIDFactoryTest.java
@@ -1,5 +1,7 @@
 package com.izettle.java;
 
+import static com.izettle.java.UUIDFactory.parse;
+import static com.izettle.java.UUIDFactory.toBase64String;
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -14,6 +16,7 @@ import java.util.UUID;
 import org.junit.Test;
 
 public class UUIDFactoryTest {
+
     private static final String UNENCODED_UUID4_STRING = "cdaed56d-8712-414d-b346-01905d0026fe";
     private static final String ENCODED_UUID4_STRING = "za7VbYcSQU2zRgGQXQAm_g";
 
@@ -23,6 +26,17 @@ public class UUIDFactoryTest {
     @Test
     public void shouldCreateUUID4Successfully() {
         assertOnBase64String(UUIDFactory.createUUID4AsString());
+    }
+
+    @Test
+    public void shouldParseUUIDSuccessfully() {
+        assertEquals(ENCODED_UUID1_STRING, toBase64String(parse(ENCODED_UUID1_STRING)));
+        assertEquals(ENCODED_UUID1_STRING, toBase64String(parse(UNENCODED_UUID1_STRING)));
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void shouldThrowWhenParsingInvalidString() {
+        UUIDFactory.parse("");
     }
 
     @Test
@@ -84,7 +98,7 @@ public class UUIDFactoryTest {
     @Test
     public void itShouldBeReflectiveBetweenLongsAndBytes() {
         Random rnd = new Random();
-        for(int i = 0; i < 1000; i++){
+        for (int i = 0; i < 1000; i++) {
             long l = rnd.nextLong();
             assertEquals(l, UUIDFactory.bytesToLong(UUIDFactory.longToBytes(l)));
         }
@@ -92,7 +106,7 @@ public class UUIDFactoryTest {
 
     @Test
     public void itShouldBeReflectiveBetweenB64AndUUID() {
-        for(int i = 0; i < 1000; i++){
+        for (int i = 0; i < 1000; i++) {
             UUID uuid = UUID.randomUUID();
             assertEquals(uuid, UUIDFactory.fromBase64String(UUIDFactory.toBase64String(uuid)));
         }
@@ -150,7 +164,7 @@ public class UUIDFactoryTest {
 
     @Test
     public void shouldCreateAlternativeForVersion4InTheSameWayAsBefore() {
-        for(int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 1000; i++) {
             String uuidString = UUIDFactory.createUUID4AsString();
             String oldAlternative = createAlternative_oldVersion(uuidString);
             String newAlternative = UUIDFactory.createAlternative(uuidString);
@@ -160,7 +174,7 @@ public class UUIDFactoryTest {
             assertEquals(oldAltUUID.variant(), newAltUUID.variant());
             assertEquals(oldAlternative, newAlternative);
         }
-        for(int i = 0; i < 1000; i++){
+        for (int i = 0; i < 1000; i++) {
             String uuidString = UUIDFactory.createUUID1AsString();
             UUID originalUUID = UUIDFactory.fromBase64String(uuidString);
             String alternative = UUIDFactory.createAlternative(uuidString);
@@ -174,7 +188,7 @@ public class UUIDFactoryTest {
      * This is the old version of how we did create alternative. It was originally in the UUIDFactory, but moved here as
      * it's not used anymore, but needs to be used
      * for verifying that we haven't broken anything
-    */
+     */
     private static String createAlternative_oldVersion(String uuid) {
         final byte[] mask = new byte[]{(byte) 0x01};
         byte[] bytes = UUIDFactory.uuidToByteArray(uuid);


### PR DESCRIPTION
As we're moving away from using the base64 representation of a `UUID`,
we still want to allow the old format in API's and as input parameters.
Testing for the two different versions everywhere makes the code ugly
and repetitive.

This change simply adds a parse method that will accept both versions of
the serialization format.

ping @niklas-izettle  