### PR TITLE
Metadata to publish artifacts to maven central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: java
+script: mvn verify
+jdk:
+  - oraclejdk8
+cache:
+  directories:
+    - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -3,21 +3,9 @@
 Libraries built and used internally at iZettle.
 
 ## Releasing
-When you have made a change to the `izettle-toolbox` you need to publish it to our internal Artifactory. This is done through the _Maven release_ plugin.
 
-### Prerequsite
-* `settings.xml` file with credentials to our internal Artifactory, you'll find it in [izettle-documents](https://github.com/iZettle/izettle-documents/blob/master/system/local/settings.xml).
-
-#### Setup setting.xml: (Assuming username is *arne* and maven repository is in ~/.m2 which is default)
-1. Checkout izettle-documents
-2. `cd /Users/arne/.m2`
-3. `ln -s /Users/arne/projects/izettle-documents/system/local/settings.xml`
-
-### Release steps
-1. `mvn release:prepare`
-2. `mvn release:perform`
-3. `git push`
-
+Please refer to the instructions on releasing open-source artifacts to maven
+central here: https://github.com/iZettle/izettle-maven/blob/master/README.md
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.izettle</groupId>
-        <artifactId>izettle</artifactId>
-        <version>1.8</version>
+        <artifactId>izettle-oss</artifactId>
+        <version>1.11</version>
+        <relativePath/>
     </parent>
 
     <groupId>com.izettle.toolbox</groupId>
@@ -12,32 +13,20 @@
     <packaging>pom</packaging>
     <version>1.0.66-SNAPSHOT</version>
 
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <scm>
         <url>https://github.com/iZettle/izettle-toolbox</url>
         <connection>scm:git:git://github.com/iZettle/izettle-toolbox.git</connection>
         <developerConnection>scm:git:git:@github.com:iZettle/izettle-toolbox.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>http://localhost:7070/artifactory/repo</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>snapshots</id>
-            <url>http://localhost:7070/artifactory/libs-snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <modules>
         <module>izettle-java</module>


### PR DESCRIPTION
- Inherits plugin information from izettle-oss POM
- Fixes to pass new new-line-at-end-of-file checkstyle rule
- Adds Travis CI configuration

Tested locally by running:

```
docker run -it --rm --name my-maven-project -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven maven:3 mvn clean install
```
