### PR TITLE
JsonSerializer: add InstantModule to serialize as Instants.

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/serialization/InstantModule.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/serialization/InstantModule.java
@@ -1,0 +1,54 @@
+package com.izettle.messaging.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class InstantModule extends SimpleModule {
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+        .withZone(ZoneId.of("UTC"));
+
+    public InstantModule() {
+        this.addSerializer(new InstantSerializer());
+        this.addDeserializer(Instant.class, new InstantDeserializer());
+    }
+
+    public static class InstantSerializer extends JsonSerializer<Instant> {
+        @Override
+        public void serialize(
+            Instant value,
+            JsonGenerator jsonGenerator,
+            SerializerProvider serializers
+        ) throws IOException {
+            jsonGenerator.writeString(DATE_TIME_FORMATTER.format(value));
+        }
+
+        @Override
+        public Class<Instant> handledType() {
+            return Instant.class;
+        }
+    }
+
+    private static class InstantDeserializer extends JsonDeserializer<Instant> {
+        @Override
+        public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            try {
+                return LocalDateTime.parse(p.getText(), DATE_TIME_FORMATTER).toInstant(ZoneOffset.UTC);
+            } catch (DateTimeParseException e) {
+                return Instant.parse(p.getText());
+            }
+        }
+    }
+}

--- a/izettle-messaging/src/main/java/com/izettle/messaging/serialization/JsonSerializer.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/serialization/JsonSerializer.java
@@ -7,9 +7,12 @@ public class JsonSerializer {
     private static final ObjectMapper JSON_MAPPER = createInstance();
 
     private static ObjectMapper createInstance() {
-        ObjectMapper result = new ObjectMapper();
-        result.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        return result;
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        //Configure java.time.Instant serialization/deserialization.
+        objectMapper.registerModule(new InstantModule());
+
+        return objectMapper;
     }
 
     public static ObjectMapper getInstance() {

--- a/izettle-messaging/src/test/java/com/izettle/messaging/serialization/InstantModuleTest.java
+++ b/izettle-messaging/src/test/java/com/izettle/messaging/serialization/InstantModuleTest.java
@@ -1,0 +1,35 @@
+package com.izettle.messaging.serialization;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import org.junit.Test;
+
+public class InstantModuleTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper().registerModule(new InstantModule());
+
+    @Test
+    public void testInstantSerializationDeserialization() throws Exception {
+        String instantString = objectMapper.writeValueAsString(Instant.EPOCH);
+        assertEquals("\"1970-01-01T00:00:00.000+0000\"", instantString);
+        Instant actualEpoch = objectMapper.readValue(instantString, Instant.class);
+        assertEquals(Instant.EPOCH, actualEpoch);
+    }
+
+    @Test
+    public void testAdamsBirthdaySerialization() throws Exception {
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZone(ZoneId.of("UTC"));
+        Instant ctoEpoch = LocalDateTime.parse("1974-05-25T13:33:33.337+0000", format).toInstant(ZoneOffset.UTC);
+        String instantString = objectMapper.writeValueAsString(ctoEpoch);
+        assertEquals("\"1974-05-25T13:33:33.337+0000\"", instantString);
+        Instant deserialized = objectMapper.readValue(instantString, Instant.class);
+        assertEquals(ctoEpoch, deserialized);
+
+    }
+}


### PR DESCRIPTION
Instants will now be serialized as ISO8601/RFC3339 formatted string like
`yyyy-MM-dd'T'HH:mm:ss.SSSZ`.

@nzroller can you check, please?