### PR TITLE
JsonSerializer: use Jackson java.time serialization module.

### DIFF
--- a/izettle-messaging/pom.xml
+++ b/izettle-messaging/pom.xml
@@ -47,6 +47,11 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/izettle-messaging/src/main/java/com/izettle/messaging/serialization/JsonSerializer.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/serialization/JsonSerializer.java
@@ -2,6 +2,7 @@ package com.izettle.messaging.serialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
 
 public class JsonSerializer {
     private static final ObjectMapper JSON_MAPPER = createInstance();
@@ -9,6 +10,7 @@ public class JsonSerializer {
     private static ObjectMapper createInstance() {
         ObjectMapper result = new ObjectMapper();
         result.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        result.registerModule(new JSR310Module());
         return result;
     }
 


### PR DESCRIPTION
For now, on version 2.5.1 of Jackson, we use the JSR310Module. That
will in a later upgrade be replaced by the JavaTimeModule(which
deprecates the JSR310Module).

Closes https://github.com/iZettle/izettle-toolbox/pull/137  

@nzroller 