### PR TITLE
Add helper class to check Strings for CR/LF

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/HttpRequestValidatingHelper.java
+++ b/izettle-java/src/main/java/com/izettle/java/HttpRequestValidatingHelper.java
@@ -1,0 +1,30 @@
+package com.izettle.java;
+
+/**
+ *  Helper methods to check input HTTPRequest values for use in HTTPResponse
+ */
+public class HttpRequestValidatingHelper {
+
+    /**
+     * Guard against HTTP Response Splitting attack - throw exception if /r or /n found in value to be used in a header
+     * Info:
+     * Ref: http://projects.webappsec.org/HTTP-Response-Splitting
+     * Intro to response splitting: http://www.securiteam.com/securityreviews/5WP0E2KFGK.html
+     * OWASP response splitting page: https://www.owasp.org/index.php/HTTP_Response_Splitting
+     * How to Test: https://www.owasp.org/index.php/Testing_for_HTTP_Splitting/Smuggling_(OTG-INPVAL-016)
+     * Wikipedia Response Splitting page: https://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
+     * @param input String (found from a HTTPRequest)
+     * @return the input String unchanged (for use in HTTPReponse)
+     * @throws IllegalArgumentException if a CR/LF found in the string
+     */
+    public static String checkValueForNewline(String input) throws IllegalArgumentException {
+        if (input == null || input.length() == 0) {
+            return "";
+        }
+        if (input.indexOf('\r') > 0 || input.indexOf('\n') > 0) {
+            throw new IllegalArgumentException("CR and/or LF found in param to be used in response header");
+        }
+        return input;
+    }
+}

--- a/izettle-java/src/test/java/com/izettle/java/HttpRequestValidatingHelperTest.java
+++ b/izettle-java/src/test/java/com/izettle/java/HttpRequestValidatingHelperTest.java
@@ -1,0 +1,52 @@
+package com.izettle.java;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class HttpRequestValidatingHelperTest {
+    private String inputString;
+    private Boolean expectedResult;
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Parameterized.Parameters
+    public static Collection primeNumbers() {
+        return Arrays.asList(new Object[][]{
+            {"one\rtwo", false},
+            {"one\ntwo", false},
+            {"one\r\ntwo", false},
+            {"one\r\ntwo\r\n", false},
+            {"\r\none\r\ntwo\r\n", false},
+            {"\r\none\r\ntwo\r\n", false},
+            {"onetwo", true},
+            {"one two", true},
+        });
+    }
+
+    public HttpRequestValidatingHelperTest(
+        String inputString,
+        Boolean expectedResult
+    ) {
+        this.inputString = inputString;
+        this.expectedResult = expectedResult;
+    }
+
+    @Test
+    public void shouldGuardValueAgainstResponseSplitterAttack() throws Exception {
+        if (!expectedResult) {
+            thrown.expect(IllegalArgumentException.class);
+            thrown.expectMessage("CR and/or LF found in param to be used in response header");
+        }
+        String result = HttpRequestValidatingHelper.checkValueForNewline(inputString);
+        assertThat(result, is(inputString));
+    }
+}


### PR DESCRIPTION
Tto mitigate against HTTP response splitting attack.  This will be used in vulnerable classes that reuse HTTPRequest input strings/values in HTTPResponse Header outputs.
* Guard against HTTP Response Splitting attack - throw exception if \r or \n found in value to be used in a header

## Info:
* Ref: http://projects.webappsec.org/HTTP-Response-Splitting
* Intro to response splitting: http://www.securiteam.com/securityreviews/5WP0E2KFGK.html
* OWASP response splitting page: https://www.owasp.org/index.php/HTTP_Response_Splitting
* How to Test: https://www.owasp.org/index.php/Testing_for_HTTP_Splitting/Smuggling_(OTG-INPVAL-016)
* Wikipedia Response Splitting page: https://en.wikipedia.org/wiki/HTTP_response_splitting