### PR TITLE
Catch amazon service exception when sending batch to queue

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
@@ -118,7 +118,7 @@ public class QueueServiceSender<M> implements MessageQueueProducer<M>, MessagePu
                     new SendMessageRequest(queueUrl, encryptedBody)
             );
             return new MessageReceipt(sendMessageResult.getMessageId(), jsonBody);
-        } catch (IOException | CryptographyException e) {
+        } catch (AmazonServiceException | IOException | CryptographyException e) {
             throw new MessagingException("Failed to post message: " + message.getClass().toString(), e);
         }
     }

--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
@@ -4,6 +4,7 @@ import static com.izettle.java.CollectionUtils.partition;
 import static com.izettle.java.ValueChecks.anyEmpty;
 import static com.izettle.java.ValueChecks.empty;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
@@ -157,7 +158,7 @@ public class QueueServiceSender<M> implements MessageQueueProducer<M>, MessagePu
                 allEntries.add(new SendMessageBatchRequestEntry(String.valueOf(messageIdInBatch), messageBody));
             }
             sendMessageBatch(allEntries);
-        } catch (IOException | CryptographyException e) {
+        } catch (AmazonServiceException | IOException | CryptographyException e) {
             throw new MessagingException("Failed to post messages: " + messages.getClass().toString(), e);
         }
     }

--- a/izettle-messaging/src/test/java/com/izettle/messaging/QueueServiceSenderTest.java
+++ b/izettle-messaging/src/test/java/com/izettle/messaging/QueueServiceSenderTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.EmptyBatchRequestException;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
@@ -45,11 +44,8 @@ public class QueueServiceSenderTest {
     }
 
     @Test
-    public void shouldNotSendEmptyBatch() throws Exception {
+    public void shouldSendBatchesInSizeOfTen() throws Exception {
         ArgumentCaptor<SendMessageBatchRequest> captor = ArgumentCaptor.forClass(SendMessageBatchRequest.class);
-
-        SendMessageBatchRequest emptyRequest = new SendMessageBatchRequest("queue-url-can-be-anything", new ArrayList<SendMessageBatchRequestEntry>());
-        when(mockAmazonSQS.sendMessageBatch(emptyRequest)).thenThrow(new EmptyBatchRequestException("Empty yo"));
 
         messagePublisher.postBatch(messageBatch(10), subject);
         verify(mockAmazonSQS, times(1)).sendMessageBatch(captor.capture());


### PR DESCRIPTION
Methods in QueueServiceSender now catch AmazonServiceException which might be thrown if Amazon-service is offline or URL is faulty.
Cleaned up test case for QueueServiceSender where EmptyBatchRequestException is never thrown.
Renamed test to better represent what it does.