### PR TITLE
Cleanup: Validate items and discount early in constructor

### DIFF
--- a/izettle-cart/src/main/java/com/izettle/cart/Cart.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/Cart.java
@@ -29,7 +29,9 @@ public class Cart<T extends Item<T, D>, D extends Discount<D>, K extends Discoun
      * @param serviceCharge The applied service charge, possibly null
      */
     public Cart(final List<T> items, final List<K> discounts, final S serviceCharge) {
+        ItemUtils.validateItems(items);
         final List<T> itemList = coalesce(items, Collections.<T>emptyList());
+        DiscountUtils.validateDiscounts(discounts);
         final List<K> discountList = coalesce(discounts, Collections.<K>emptyList());
         this.grossValue = CartUtils.getGrossValue(itemList);
         this.discountValue = CartUtils.getTotalDiscountValue(discountList, grossValue, itemList);

--- a/izettle-cart/src/main/java/com/izettle/cart/DiscountUtils.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/DiscountUtils.java
@@ -1,0 +1,28 @@
+package com.izettle.cart;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+
+class DiscountUtils {
+
+    private DiscountUtils() {
+    }
+
+    static <D extends Discount> void validateDiscounts(final Collection<D> discounts) {
+        if (discounts == null) {
+            return;
+        }
+        for (D item : discounts) {
+            validateDiscount(item);
+        }
+    }
+
+    private static <D extends Discount> void validateDiscount(final D discount) {
+        if (discount.getQuantity() == null) {
+            throw new IllegalArgumentException("Discount cannot have null quantity: " + discount);
+        }
+        if (discount.getQuantity().compareTo(BigDecimal.ZERO) == 0) {
+            throw new IllegalArgumentException("Discount cannot have ZERO quantity: " + discount);
+        }
+    }
+}

--- a/izettle-cart/src/main/java/com/izettle/cart/ItemUtils.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/ItemUtils.java
@@ -5,8 +5,13 @@ import static com.izettle.cart.CartUtils.getNonRoundedDiscountValue;
 import static com.izettle.cart.CartUtils.round;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 
 class ItemUtils {
+
+    private ItemUtils() {
+    }
+
     /**
      * Returns the gross value of the item. Gross is the quantity multiplied with unit price
      * and rounded to a long using {@link com.izettle.cart.CartUtils#round(java.math.BigDecimal)}, VAT is included.
@@ -43,8 +48,25 @@ class ItemUtils {
         return null;
     }
 
-
     private static BigDecimal getExactGrossValue(final Item item) {
         return item.getQuantity().multiply(BigDecimal.valueOf(item.getUnitPrice()));
+    }
+
+    static <T extends Item> void validateItems(final Collection<T> items) {
+        if (items == null) {
+            return;
+        }
+        for (T item : items) {
+            validateItem(item);
+        }
+    }
+
+    static <T extends Item> void validateItem(final T item) {
+        if (item.getQuantity() == null) {
+            throw new IllegalArgumentException("Item cannot have null quantity: " + item);
+        }
+        if (item.getQuantity().compareTo(BigDecimal.ZERO) == 0) {
+            throw new IllegalArgumentException("Item cannot have ZERO quantity: " + item);
+        }
     }
 }

--- a/izettle-cart/src/test/java/com/izettle/cart/CartTest.java
+++ b/izettle-cart/src/test/java/com/izettle/cart/CartTest.java
@@ -548,6 +548,22 @@ public class CartTest {
         assertThat(cart.getDiscountVat()).isEqualTo(13L);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowWhenDiscountsInvalid() {
+        ArrayList<TestDiscount> discounts = new ArrayList<TestDiscount>();
+        BigDecimal quantity = null;
+        discounts.add(new TestDiscount(null, 50d, quantity));
+        new Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge>(null, discounts, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowWhenItemsInvalid() {
+        ArrayList<TestItem> items = new ArrayList<TestItem>();
+        BigDecimal quantity = null;
+        items.add(new TestItem("", 100L, 10f, quantity, new TestDiscount(100L, null, BigDecimal.ONE)));
+        new Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge>(items, null, null);
+    }
+
     //Dummy method for bypassing ambiguity against two similar Assert.assertEqual methods
     private void assEq(Long one, Long two) {
         assertEquals(one, two);


### PR DESCRIPTION
To get a clearer error thrown to the caller when construction fails.

Items with null for quantity previously generated this exception:

```
java.lang.NullPointerException: null
        at com.izettle.cart.ItemUtils.getExactGrossValue(ItemUtils.java:53)
        at com.izettle.cart.ItemUtils.getGrossValue(ItemUtils.java:22)
        at com.izettle.cart.ItemUtils.getValue(ItemUtils.java:34)
        at com.izettle.cart.CartUtils.getGrossValue(CartUtils.java:31)
        at com.izettle.cart.Cart.<init>(Cart.java:36)
        at com.izettle.cart.CartTest.itShouldThrowWhenItemsInvalid(CartTest.java:565)
```

After this change, this will be thrown:

```
java.lang.IllegalArgumentException: Item cannot have null quantity: TestItem{ unitPrice = 100, vatPercentage = 10.0, quantity = null, name = , discount = TestDiscount{ amount = 100, percentage = null, quantity = 1}}
        at com.izettle.cart.ItemUtils.validateItem(ItemUtils.java:67)
        at com.izettle.cart.ItemUtils.validateItems(ItemUtils.java:61)
        at com.izettle.cart.Cart.<init>(Cart.java:32)
        at com.izettle.cart.CartTest.itShouldThrowWhenItemsInvalid(CartTest.java:565)
```

ping @ssprang 