### PR TITLE
[Do not merge] Added a mapper for DataStax's Cassandra driver that doesn't require setters

### DIFF
--- a/datastax-cassandra-mapper/pom.xml
+++ b/datastax-cassandra-mapper/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>izettle-toolbox</artifactId>
+		<groupId>com.izettle.toolbox</groupId>
+		<version>1.0.62-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>datastax-cassandra-mapper</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.cassandraunit</groupId>
+			<artifactId>cassandra-unit</artifactId>
+			<version>2.1.9.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.datastax.cassandra</groupId>
+			<artifactId>cassandra-driver-mapping</artifactId>
+			<version>2.1.9</version>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.3.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/datastax-cassandra-mapper/src/main/java/com/datastax/driver/mapping/CassandraMapper.java
+++ b/datastax-cassandra-mapper/src/main/java/com/datastax/driver/mapping/CassandraMapper.java
@@ -1,0 +1,102 @@
+package com.datastax.driver.mapping;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.izettle.cassandra.MapBackedDataRow;
+import com.izettle.cassandra.RowBackedDataRow;
+import com.izettle.cassandra.RowMapper;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.StreamSupport;
+
+public class CassandraMapper<T> {
+
+    private final Session session;
+    private final Mapper<T> mapper;
+    private final RowMapper<T> rowMapper;
+    private final MappingManagerModified mappingManager;
+    private Class<T> klass;
+
+    public CassandraMapper(MappingManagerModified mappingManager, RowMapper<T> rowMapper, Class<T> klass) {
+        this.mappingManager = requireNonNull(mappingManager);
+        this.rowMapper = requireNonNull(rowMapper);
+        this.klass = requireNonNull(klass);
+        this.mapper = mappingManager.mapper(klass);
+        this.session = mapper.getManager().getSession();
+    }
+
+    public T get(Object... objects) {
+        ResultSet resultSet = session.execute(mapper.getQuery(objects));
+
+        Row row = resultSet.one();
+        if (row == null) {
+            throw new NoSuchElementException();
+        }
+
+        return rowMapper.map(new MapBackedDataRow(toMap(row)));
+    }
+
+    public T query(String query, Object... values) {
+        ResultSet resultSet = session.execute(query, values);
+
+        Row row = resultSet.one();
+        if (row == null) {
+            throw new NoSuchElementException();
+        }
+
+        return rowMapper.map(new RowBackedDataRow(row));
+    }
+
+    public List<T> queryList(String query, Object... values) {
+        ResultSet resultSet = session.execute(query, values);
+
+        return StreamSupport.stream(resultSet.spliterator(), false)
+            .map(RowBackedDataRow::new)
+            .map(rowMapper::map)
+            .collect(toList());
+    }
+
+    public void save(T entity, Mapper.Option... options) {
+        mapper.save(entity, options);
+    }
+
+    public void delete(T entity) {
+        mapper.delete(entity);
+    }
+
+    private Map<String, Object> toMap(Row row) {
+        Map<String, Object> values = new HashMap<>();
+
+        EntityMapper<T> entityMapper = mappingManager.entityMapper(klass);
+
+        for (ColumnMapper<T> cm : entityMapper.allColumns()) {
+            String name = cm.getAlias() != null ? cm.getAlias() : cm.getColumnName();
+            if (!row.getColumnDefinitions().contains(name)) {
+                continue;
+            }
+            ByteBuffer bytes = row.getBytesUnsafe(name);
+            if (bytes != null) {
+                values.put(
+                    cm.getColumnName().replace("\"", ""),
+                    cm.getDataType()
+                        .deserialize(
+                            bytes,
+                            mappingManager.getSession()
+                                .getCluster()
+                                .getConfiguration()
+                                .getProtocolOptions()
+                                .getProtocolVersionEnum()
+                        )
+                );
+            }
+        }
+        return values;
+    }
+}

--- a/datastax-cassandra-mapper/src/main/java/com/datastax/driver/mapping/MappingManagerModified.java
+++ b/datastax-cassandra-mapper/src/main/java/com/datastax/driver/mapping/MappingManagerModified.java
@@ -1,0 +1,28 @@
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.Session;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MappingManagerModified extends MappingManager {
+
+    private final Map<String, EntityMapper<?>> entityMapperCache = new HashMap<>();
+
+    public MappingManagerModified(Session session) {
+        super(session);
+    }
+
+    @Override
+    public <T> Mapper<T> mapper(Class<T> klass) {
+        EntityMapper<T> entityMapper = AnnotationParser.parseEntity(klass, ReflectionMapperModified.factory(), this);
+        return new Mapper<>(this, klass, entityMapper);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> EntityMapper<T> entityMapper(Class<T> klass) {
+        return (EntityMapper<T>) entityMapperCache.computeIfAbsent(
+            klass.getName(),
+            className -> AnnotationParser.parseEntity(klass, ReflectionMapperModified.factory(), this)
+        );
+    }
+}

--- a/datastax-cassandra-mapper/src/main/java/com/datastax/driver/mapping/ReflectionMapperModified.java
+++ b/datastax-cassandra-mapper/src/main/java/com/datastax/driver/mapping/ReflectionMapperModified.java
@@ -1,0 +1,180 @@
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.DataType;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * An {@link EntityMapper} implementation that use reflection to read and write fields
+ * of an entity.
+ */
+class ReflectionMapperModified<T> extends EntityMapper<T> {
+
+    private static ReflectionFactory factory = new ReflectionFactory();
+
+    private ReflectionMapperModified(
+        Class<T> entityClass,
+        String keyspace,
+        String table,
+        ConsistencyLevel writeConsistency,
+        ConsistencyLevel readConsistency
+    ) {
+        super(entityClass, keyspace, table, writeConsistency, readConsistency);
+    }
+
+    public static Factory factory() {
+        return factory;
+    }
+
+    @Override
+    public T newEntity() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static class LiteralMapper<T> extends ColumnMapper<T> {
+
+        private final Method readMethod;
+
+        private LiteralMapper(Field field, int position, PropertyDescriptor pd, AtomicInteger columnNumber) {
+            this(field, extractSimpleType(field), position, pd, columnNumber);
+        }
+
+        private LiteralMapper(
+            Field field,
+            DataType type,
+            int position,
+            PropertyDescriptor pd,
+            AtomicInteger columnCounter
+        ) {
+            super(field, type, position, columnCounter);
+            this.readMethod = pd.getReadMethod();
+        }
+
+        @Override
+        public Object getValue(T entity) {
+            try {
+                return readMethod.invoke(entity);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Could not get field '" + fieldName + "'");
+            } catch (Exception e) {
+                throw new IllegalStateException(
+                    "Unable to access getter for '" + fieldName + "' in " + entity.getClass().getName(),
+                    e
+                );
+            }
+        }
+
+        @Override
+        public void setValue(Object entity, Object value) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class EnumMapper<T> extends LiteralMapper<T> {
+
+        private final EnumType enumType;
+        private final Map<String, Object> fromString;
+
+        private EnumMapper(
+            Field field,
+            int position,
+            PropertyDescriptor pd,
+            EnumType enumType,
+            AtomicInteger columnCounter
+        ) {
+            super(field, enumType == EnumType.STRING ? DataType.text() : DataType.cint(), position, pd, columnCounter);
+            this.enumType = enumType;
+
+            if (enumType == EnumType.STRING) {
+                fromString = new HashMap<>(javaType.getEnumConstants().length);
+                for (Object constant : javaType.getEnumConstants()) {
+                    fromString.put(constant.toString().toLowerCase(), constant);
+                }
+            } else {
+                fromString = null;
+            }
+        }
+
+        @SuppressWarnings("rawtypes")
+        @Override
+        public Object getValue(T entity) {
+            Object value = super.getValue(entity);
+            switch (enumType) {
+                case STRING:
+                    return (value == null) ? null : value.toString();
+                case ORDINAL:
+                    return (value == null) ? null : ((Enum) value).ordinal();
+            }
+            throw new AssertionError();
+        }
+
+        @Override
+        public void setValue(Object entity, Object value) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static DataType extractSimpleType(Field f) {
+        Type type = f.getGenericType();
+
+        assert !(type instanceof ParameterizedType);
+
+        if (!(type instanceof Class)) {
+            throw new IllegalArgumentException(String.format("Cannot map class %s for field %s", type, f.getName()));
+        }
+
+        return TypeMappings.getSimpleType((Class<?>) type, f.getName());
+    }
+
+    private static class ReflectionFactory implements Factory {
+
+        public <T> EntityMapper<T> create(
+            Class<T> entityClass,
+            String keyspace,
+            String table,
+            ConsistencyLevel writeConsistency,
+            ConsistencyLevel readConsistency
+        ) {
+            return new ReflectionMapperModified<>(entityClass, keyspace, table, writeConsistency, readConsistency);
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        public <T> ColumnMapper<T> createColumnMapper(
+            Class<T> entityClass,
+            Field field,
+            int position,
+            MappingManager mappingManager,
+            AtomicInteger columnCounter
+        ) {
+            String fieldName = field.getName();
+            try {
+                for (PropertyDescriptor pd : Introspector.getBeanInfo(field.getDeclaringClass()).getPropertyDescriptors()) {
+                    if (pd.getReadMethod() != null && field.getName().equals(pd.getName())) {
+                        if (field.getType().isEnum()) {
+                            return new EnumMapper<>(field, position, pd, AnnotationParser.enumType(field), columnCounter);
+                        }
+
+                        if (field.getGenericType() instanceof ParameterizedType) {
+                            InferredCQLType inferredCQLType = InferredCQLType.from(field, mappingManager);
+                            return new LiteralMapper<>(field, inferredCQLType.dataType, position, pd, columnCounter);
+                        }
+                        return new LiteralMapper<>(field, position, pd, columnCounter);
+                    }
+                }
+
+            } catch (IntrospectionException e) {
+                // pass through
+            }
+            throw new IllegalArgumentException("Cannot find matching getter for field '" + fieldName + "'");
+        }
+    }
+}

--- a/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/DataRow.java
+++ b/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/DataRow.java
@@ -1,0 +1,8 @@
+package com.izettle.cassandra;
+
+public interface DataRow {
+
+    String getString(String name);
+
+    int getInt(String name);
+}

--- a/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/MapBackedDataRow.java
+++ b/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/MapBackedDataRow.java
@@ -1,0 +1,22 @@
+package com.izettle.cassandra;
+
+import java.util.Map;
+
+public class MapBackedDataRow implements DataRow {
+
+    private final Map<String, Object> map;
+
+    public MapBackedDataRow(Map<String, Object> map) {
+        this.map = map;
+    }
+
+    @Override
+    public String getString(String name) {
+        return (String) map.get(name);
+    }
+
+    @Override
+    public int getInt(String name) {
+        return (int) map.get(name);
+    }
+}

--- a/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/RowBackedDataRow.java
+++ b/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/RowBackedDataRow.java
@@ -1,0 +1,22 @@
+package com.izettle.cassandra;
+
+import com.datastax.driver.core.Row;
+
+public class RowBackedDataRow implements DataRow {
+
+    private final Row row;
+
+    public RowBackedDataRow(Row row) {
+        this.row = row;
+    }
+
+    @Override
+    public String getString(String name) {
+        return row.getString(name);
+    }
+
+    @Override
+    public int getInt(String name) {
+        return row.getInt(name);
+    }
+}

--- a/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/RowMapper.java
+++ b/datastax-cassandra-mapper/src/main/java/com/izettle/cassandra/RowMapper.java
@@ -1,0 +1,8 @@
+package com.izettle.cassandra;
+
+@FunctionalInterface
+public interface RowMapper<T> {
+
+    T map(DataRow values);
+
+}

--- a/datastax-cassandra-mapper/src/test/java/izettle/cassandra/CassandraMapperTest.java
+++ b/datastax-cassandra-mapper/src/test/java/izettle/cassandra/CassandraMapperTest.java
@@ -1,0 +1,95 @@
+package izettle.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.CassandraMapper;
+import com.datastax.driver.mapping.MappingManagerModified;
+import java.util.NoSuchElementException;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CassandraMapperTest {
+
+    public static final User ALICE = new User(1, "alice@example.org", User.Gender.FEMALE);
+    public static final User BOB = new User(2, "bob@example.org", User.Gender.MALE);
+
+    private static Session session;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+        Cluster cluster = Cluster
+            .builder()
+            .addContactPoint("127.0.0.1")
+            .withPort(9142)
+            .build();
+        session = cluster.connect();
+    }
+
+    @Before
+    public void before() {
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+        session.execute("CREATE KEYSPACE test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
+        session.execute("USE test;");
+        session.execute("CREATE TABLE user (id int PRIMARY KEY, email varchar, gender varchar);");
+    }
+
+    @Test
+    public void shouldSaveAndGetObject() throws Exception {
+
+        MappingManagerModified mappingManager = new MappingManagerModified(session);
+
+        CassandraMapper<User> mapper = new CassandraMapper<>(mappingManager, new UserMapper(), User.class);
+
+        mapper.save(ALICE);
+
+        assertThat(mapper.get(ALICE.getId()))
+            .isEqualTo(ALICE);
+    }
+
+    @Test
+    public void shouldQuerySingleObjects() throws Exception {
+
+        MappingManagerModified mappingManager = new MappingManagerModified(session);
+
+        CassandraMapper<User> mapper = new CassandraMapper<>(mappingManager, new UserMapper(), User.class);
+
+        mapper.save(ALICE);
+
+        assertThat(mapper.query("SELECT id, email, gender FROM user WHERE id = ?", ALICE.getId()))
+            .isEqualTo(ALICE);
+
+    }
+
+    @Test
+    public void shouldQueryMultipleObjects() throws Exception {
+
+        MappingManagerModified mappingManager = new MappingManagerModified(session);
+
+        CassandraMapper<User> mapper = new CassandraMapper<>(mappingManager, new UserMapper(), User.class);
+
+        mapper.save(ALICE);
+        mapper.save(BOB);
+
+        assertThat(mapper.queryList("SELECT * FROM user WHERE id IN (1, 2);"))
+            .containsExactly(ALICE, BOB);
+
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void shouldDeleteObject() throws Exception {
+
+        MappingManagerModified mappingManager = new MappingManagerModified(session);
+
+        CassandraMapper<User> mapper = new CassandraMapper<>(mappingManager, new UserMapper(), User.class);
+
+        mapper.save(ALICE);
+        mapper.delete(ALICE);
+
+        mapper.get(ALICE.getId());
+    }
+}

--- a/datastax-cassandra-mapper/src/test/java/izettle/cassandra/User.java
+++ b/datastax-cassandra-mapper/src/test/java/izettle/cassandra/User.java
@@ -1,0 +1,69 @@
+package izettle.cassandra;
+
+import com.datastax.driver.mapping.EnumType;
+import com.datastax.driver.mapping.annotations.Enumerated;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+
+@Table(name = "user", keyspace = "test")
+public class User {
+
+    public enum Gender {
+        MALE, FEMALE
+    }
+
+    @PartitionKey
+    private final int id;
+
+    private final String email;
+
+    @Enumerated(EnumType.STRING)
+    private final Gender gender;
+
+    public User(int id, String email, Gender gender) {
+        this.id = id;
+        this.email = email;
+        this.gender = gender;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Gender getGender() {
+        return gender;
+    }
+
+    @Override
+    public String toString() {
+        return "izettle.cassandra.User{" +
+            "id=" + id +
+            ", email='" + email + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        User user = (User) o;
+
+        if (id != user.id) return false;
+        if (!email.equals(user.email)) return false;
+        return gender == user.gender;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id;
+        result = 31 * result + email.hashCode();
+        result = 31 * result + gender.hashCode();
+        return result;
+    }
+}

--- a/datastax-cassandra-mapper/src/test/java/izettle/cassandra/UserMapper.java
+++ b/datastax-cassandra-mapper/src/test/java/izettle/cassandra/UserMapper.java
@@ -1,0 +1,11 @@
+package izettle.cassandra;
+
+import com.izettle.cassandra.DataRow;
+import com.izettle.cassandra.RowMapper;
+
+public class UserMapper implements RowMapper<User> {
+    @Override
+    public User map(DataRow row) {
+        return new User(row.getInt("id"), row.getString("email"), User.Gender.valueOf(row.getString("gender")));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>izettle-cart</module>
         <module>izettle-emv</module>
         <module>izettle-jdbi</module>
+        <module>datastax-cassandra-mapper</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
I would like your thoughts on whether this is a worthwhile effort. This mapper builds on DataStax's mapper, but eliminates the need for mapped classes to have setters for all fields (uses a JDBI-style mapper interface instead).

Since the DataStax driver is not designed to be extended/modified, some classes has to copy a lot of code and live in the `datastax` package.

Advantages:
  - No setters required. Our objects can continue to be immutable.
  - Builds on Datastax's mapper, so it's easy to switch to that one if they improve.

Disadvantages:
  - We have to maintain this mapper.
  - The implementation is not very pretty (since Datastax's mapper is not designed to be modified).
  - It doesn't support Accessors (and possibly other things).

Ping @iZettle/partnerapps 