### PR TITLE
Izettle-java use java8

### DIFF
--- a/izettle-java/pom.xml
+++ b/izettle-java/pom.xml
@@ -15,8 +15,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/izettle-java/src/main/java/com/izettle/java/CollectionUtils.java
+++ b/izettle-java/src/main/java/com/izettle/java/CollectionUtils.java
@@ -36,7 +36,7 @@ public class CollectionUtils {
         if (largeCollection == null) {
             return null;
         }
-        List<Collection<T>> retList = new LinkedList<Collection<T>>();
+        List<Collection<T>> retList = new LinkedList<>();
         Collection<T> part = null;
         for (T v : largeCollection) {
             if (part != null && part.size() == partitionSize) {
@@ -46,11 +46,11 @@ public class CollectionUtils {
             if (part == null) {
                 //Figure out what kind of collection this is, so that we don't break sorting etc
                 if (largeCollection instanceof SortedSet) {
-                    part = new TreeSet<T>();
+                    part = new TreeSet<>();
                 } else if (largeCollection instanceof Set) {
-                    part = new HashSet<T>();
+                    part = new HashSet<>();
                 } else if (largeCollection instanceof List) {
-                    part = new LinkedList<T>();
+                    part = new LinkedList<>();
                 } else {
                     throw new UnsupportedOperationException("Not prepared for this type of collection: " + largeCollection.getClass().toString());
                 }

--- a/izettle-java/src/main/java/com/izettle/java/ResourceUtils.java
+++ b/izettle-java/src/main/java/com/izettle/java/ResourceUtils.java
@@ -216,7 +216,7 @@ public abstract class ResourceUtils {
             String jarPath = dirURL.getPath().substring(5, dirURL.getPath().indexOf("!")); //strip out only the JAR file
             JarFile jar = new JarFile(URLDecoder.decode(jarPath, "UTF-8"));
             Enumeration<JarEntry> entries = jar.entries(); //gives ALL entries in jar
-            Set<String> result = new HashSet<String>(); //avoid duplicates in case it is a subdirectory
+            Set<String> result = new HashSet<>(); //avoid duplicates in case it is a subdirectory
             while (entries.hasMoreElements()) {
                 String name = entries.nextElement().getName();
                 if (name.startsWith(path)) { //filter according to the path

--- a/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
+++ b/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
@@ -1,5 +1,6 @@
 package com.izettle.java;
 
+import java.time.ZoneId;
 import java.util.TimeZone;
 
 /**
@@ -623,6 +624,14 @@ public enum TimeZoneId {
     PACIFIC_ENDERBURY("Pacific/Enderbury"),
     PACIFIC_TONGATAPU("Pacific/Tongatapu"),
     ETC_GMT_MINUS14("Etc/GMT-14"),
+    ANTARCTICA_TROLL("Antarctica/Troll"),
+    ASIA_UST_NERA("Asia/Ust-Nera"),
+    ASIA_KHANDYGA("Asia/Khandyga"),
+    ASIA_CHITA("Asia/Chita"),
+    PACIFIC_BOUGAINVILLE("Pacific/Bougainville"),
+    ASIA_SREDNEKOLYMSK("Asia/Srednekolymsk"),
+    EUROPE_BUSINGEN("Europe/Busingen"),
+    AMERICA_CRESTON("America/Creston"),
     PACIFIC_KIRITIMATI("Pacific/Kiritimati");
     private final String stringId;
 
@@ -632,5 +641,9 @@ public enum TimeZoneId {
 
     public TimeZone getTimeZone() {
         return TimeZone.getTimeZone(this.stringId);
+    }
+
+    public ZoneId toZoneId() {
+        return ZoneId.of(stringId);
     }
 }

--- a/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
+++ b/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
@@ -635,7 +635,7 @@ public enum TimeZoneId {
     PACIFIC_KIRITIMATI("Pacific/Kiritimati");
     private final String stringId;
 
-    private TimeZoneId(String stringId) {
+    TimeZoneId(String stringId) {
         this.stringId = stringId;
     }
 

--- a/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
+++ b/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
@@ -644,6 +644,6 @@ public enum TimeZoneId {
     }
 
     public ZoneId toZoneId() {
-        return ZoneId.of(stringId);
+        return getTimeZone().toZoneId();
     }
 }

--- a/izettle-java/src/test/java/com/izettle/java/ArrayUtilsSpec.java
+++ b/izettle-java/src/test/java/com/izettle/java/ArrayUtilsSpec.java
@@ -54,7 +54,7 @@ public class ArrayUtilsSpec {
     @Test
     public void testConcat_List() {
 
-        List<byte[]> byteArrays = new ArrayList<byte[]>();
+        List<byte[]> byteArrays = new ArrayList<>();
         byteArrays.add(new byte[]{(byte) 0xA5, (byte) 0xB2, (byte) 0xFF, (byte) 0xD0});
         byteArrays.add(new byte[]{(byte) 0xA5, (byte) 0xB2, (byte) 0xFF, (byte) 0xD0});
 

--- a/izettle-java/src/test/java/com/izettle/java/CollectionUtilsSpec.java
+++ b/izettle-java/src/test/java/com/izettle/java/CollectionUtilsSpec.java
@@ -104,12 +104,12 @@ public class CollectionUtilsSpec {
 
     @Test
     public void itShouldPartitionCorrectCollectionClass() {
-        Collection<Integer> collection = new HashSet<Integer>(Arrays.asList(6, 5, 4, 3));
+        Collection<Integer> collection = new HashSet<>(Arrays.asList(6, 5, 4, 3));
         //Just verify that the result is a set
         List<Collection<Integer>> parts = partition(collection, 2);
         assertTrue(parts.get(0) instanceof Set);
 
-        collection = new TreeSet<Integer>(Arrays.asList(6, 5, 4, 3));
+        collection = new TreeSet<>(Arrays.asList(6, 5, 4, 3));
         //Verify that the result is a set
         parts = partition(collection, 2);
         assertTrue(parts.get(0) instanceof Set);
@@ -117,7 +117,7 @@ public class CollectionUtilsSpec {
         assertTrue(parts.get(0).iterator().next() == 3);
         assertTrue(parts.get(1).iterator().next() == 5);
 
-        collection = new ArrayList<Integer>(Arrays.asList(6, 5, 4, 3));
+        collection = new ArrayList<>(Arrays.asList(6, 5, 4, 3));
         collection.add(6);
         collection.add(5);
         collection.add(4);
@@ -132,13 +132,13 @@ public class CollectionUtilsSpec {
 
     @Test(expected = UnsupportedOperationException.class)
     public void itShouldThrowExceptionForUnhandledCollectionType() {
-        Collection<Integer> collection = new PriorityQueue<Integer>(Arrays.asList(6, 5, 4, 3));
+        Collection<Integer> collection = new PriorityQueue<>(Arrays.asList(6, 5, 4, 3));
         List<Collection<Integer>> parts = partition(collection, 2);
     }
 
     @Test
     public void itShouldToStringProperly() {
-        Set<String> set = new TreeSet<String>();
+        Set<String> set = new TreeSet<>();
         set.add("A");
         set.add("B");
         set.add("C");
@@ -147,7 +147,7 @@ public class CollectionUtilsSpec {
 
     @Test
     public void itShouldToStringEmpty() {
-        Set<String> set = new TreeSet<String>();
+        Set<String> set = new TreeSet<>();
         assertEquals("", CollectionUtils.toString(set));
     }
 

--- a/izettle-java/src/test/java/com/izettle/java/TimeZoneIdTest.java
+++ b/izettle-java/src/test/java/com/izettle/java/TimeZoneIdTest.java
@@ -1,0 +1,20 @@
+package com.izettle.java;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class TimeZoneIdTest {
+
+    @Test
+    public void testGetTimeZoneId() {
+        // Verify that each TimeZoneId can be parsed to TimeZone without errors
+        Arrays.stream(TimeZoneId.values()).forEach(TimeZoneId::getTimeZone);
+    }
+
+    @Test
+    public void testGetZoneId() {
+        // Verify that each TimeZoneId can be parsed to ZoneId without errors
+        Arrays.stream(TimeZoneId.values()).forEach(TimeZoneId::toZoneId);
+    }
+
+}

--- a/izettle-java/src/test/java/com/izettle/java/ValueChecksSpec.java
+++ b/izettle-java/src/test/java/com/izettle/java/ValueChecksSpec.java
@@ -57,8 +57,8 @@ public class ValueChecksSpec {
         assertTrue("empty string", empty(""));
         assertTrue("empty array", empty(new Object[0]));
         assertTrue("empty array", empty(new byte[0]));
-        assertTrue("empty array list", empty(new ArrayList<String>()));
-        assertTrue("empty map", empty(new HashMap<String, String>()));
+        assertTrue("empty array list", empty(new ArrayList<>()));
+        assertTrue("empty map", empty(new HashMap<>()));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ValueChecksSpec {
         assertTrue(anyEmpty(99, ""));
         assertTrue(anyEmpty(99, null));
         assertTrue(anyEmpty(null, "test"));
-        assertTrue(anyEmpty(new Object(), new HashMap<String, String>()));
+        assertTrue(anyEmpty(new Object(), new HashMap<>()));
     }
 
     @Test
@@ -239,13 +239,13 @@ public class ValueChecksSpec {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNotEmptyForMapMessageEmpty() {
-        Map<String, String> fruits = new HashMap<String, String>();
+        Map<String, String> fruits = new HashMap<>();
         ValueChecks.assertNotEmpty(fruits, "Fruitbasket must not be empty");
     }
 
     @Test
     public void testNotEmptyForMapMessage() {
-        Map<String, String> fruits = new HashMap<String, String>();
+        Map<String, String> fruits = new HashMap<>();
         fruits.put("Banana", "10");
         fruits.put("Apple", "5");
         final Map<String, String> result = ValueChecks.assertNotEmpty(fruits, "Fruitbasket must not be empty");


### PR DESCRIPTION
As we currently don't have any reasons to stay with java6 anymore.

Changed target version in pom
Switched to use diamond inference

Introduced `toZoneId` for easy access to the java8 zone object.

Also added 8 newcomers to the list of time zones: this covers all
current available zones in java8

ping @softarn 

