### PR TITLE
izettle-java instant truncator

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/InstantTruncator.java
+++ b/izettle-java/src/main/java/com/izettle/java/InstantTruncator.java
@@ -1,0 +1,114 @@
+package com.izettle.java;
+
+import static com.izettle.java.CalendarTruncator.truncateInstant;
+
+import com.izettle.java.CalendarTruncator.CalendarField;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+public class InstantTruncator {
+
+    private InstantTruncator() {
+    }
+
+    /**
+     * Truncates the given instant to the nearest previous <code>ChronoUnit</code>: all lesser units are set to zero.
+     * This method acts as a complement to the standard <code>truncatedTo</code> method available on the instant. This
+     * is to be able to truncate units larger than a "day".
+     * @param instant The instant to truncate
+     * @param timeZoneId The time zone to be taken into consideration when truncating (not really needed when truncating
+     *        smaller fields, but then again: this method is not really necessary.
+     * @param chronoUnit The chrono unit to truncate to
+     * @return a newly created copy of the given instant, with the truncated value
+     */
+    public static Instant truncate(
+        final Instant instant,
+        final TimeZoneId timeZoneId,
+        final ChronoUnit chronoUnit
+    ) {
+        if (chronoUnit.getDuration().compareTo(ChronoUnit.DAYS.getDuration()) <= 0) {
+            //Up until DAYS are supported in the native functions:
+            return ZonedDateTime
+                .ofInstant(instant, timeZoneId.toZoneId())
+                .truncatedTo(chronoUnit)
+                .toInstant();
+        } else {
+            //Need to do some special handling, as these units are not supported by the native functions (but whyyy?)
+            //We loose precision below millis here, but as we're truncating we don't need them anyway
+            return truncateInstant(timeZoneId, getCalendarField(chronoUnit), Date.from(instant)).toInstant();
+        }
+    }
+
+    /**
+     * Utility method for easily adding time to an instant. This method acts as a complement to the standard
+     * <code>Instant::plus</code> method which cannot take larger chrono units than DAY.
+     * @param instant The instant to add time to
+     * @param timeZoneId The time zone to be taken into consideration when adding
+     * @param nr the number of units to add
+     * @param chronoUnit The chrono unit to add
+     * @return a newly created copy of the given instant, with the time added
+     */
+    public static Instant plus(
+        final Instant instant,
+        final TimeZoneId timeZoneId,
+        final long nr,
+        final ChronoUnit chronoUnit
+    ) {
+        return ZonedDateTime
+            .ofInstant(instant, timeZoneId.toZoneId())
+            .plus(nr, chronoUnit)
+            .toInstant();
+    }
+
+    /**
+     * Utility method for easily subtracting time from an instant. This method acts as a complement to the standard
+     * <code>Instant::minus</code> method which cannot take larger chrono units than DAY.
+     * @param instant The instant to subtract time from
+     * @param timeZoneId The time zone to be taken into consideration when subtracting
+     * @param nr the number of units to subtract
+     * @param chronoUnit The chrono unit to subtract
+     * @return a newly created copy of the given instant, with the time subtracted
+     */
+    public static Instant minus(
+        final Instant instant,
+        final TimeZoneId timeZoneId,
+        final long nr,
+        final ChronoUnit chronoUnit
+    ) {
+        return plus(instant, timeZoneId, -nr, chronoUnit);
+    }
+
+    private static CalendarField getCalendarField(final ChronoUnit chronoUnit) {
+        switch (chronoUnit) {
+            case SECONDS:
+                return CalendarField.SECOND;
+            case MINUTES:
+                return CalendarField.MINUTE;
+            case HOURS:
+                return CalendarField.HOUR;
+            case DAYS:
+                return CalendarField.DAY;
+            case WEEKS:
+                return CalendarField.WEEK;
+            case MONTHS:
+                return CalendarField.MONTH;
+            case YEARS:
+                return CalendarField.YEAR;
+            case NANOS:
+            case MICROS:
+            case MILLIS:
+            case HALF_DAYS:
+            case DECADES:
+            case CENTURIES:
+            case MILLENNIA:
+            case ERAS:
+            case FOREVER:
+            default:
+                throw new IllegalArgumentException("Cannot truncate chronoUnit: " + chronoUnit);
+
+        }
+    }
+
+}

--- a/izettle-java/src/test/java/com/izettle/java/InstantTruncatorSpec.java
+++ b/izettle-java/src/test/java/com/izettle/java/InstantTruncatorSpec.java
@@ -1,0 +1,60 @@
+package com.izettle.java;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.Test;
+
+public class InstantTruncatorSpec {
+
+    final TimeZoneId TIME_ZONE_ID = TimeZoneId.UTC;
+
+    @Test
+    public void itShouldTruncateHours() throws Exception {
+        final Instant instant = Instant.parse("2016-02-01T20:50:01Z");
+        final Instant truncated = InstantTruncator.truncate(instant, TIME_ZONE_ID, ChronoUnit.HOURS);
+        final Instant expected = Instant.parse("2016-02-01T20:00:00Z");
+        assertEquals(expected, truncated);
+    }
+
+    @Test
+    public void itShouldTruncateWeeks() throws Exception {
+        final Instant instant = Instant.parse("2016-02-03T20:50:01Z");
+        final Instant truncated = InstantTruncator.truncate(instant, TIME_ZONE_ID, ChronoUnit.WEEKS);
+        final Instant expected = Instant.parse("2016-02-01T00:00:00Z");
+        assertEquals(expected, truncated);
+    }
+
+    @Test
+    public void itShouldTruncateYears() throws Exception {
+        final Instant instant = Instant.parse("2016-02-03T20:50:01Z");
+        final Instant truncated = InstantTruncator.truncate(instant, TIME_ZONE_ID, ChronoUnit.YEARS);
+        final Instant expected = Instant.parse("2016-01-01T00:00:00Z");
+        assertEquals(expected, truncated);
+    }
+
+    @Test
+    public void itShouldAddWeeks() throws Exception {
+        final Instant instant = Instant.now();
+        final Instant result = InstantTruncator.plus(instant, TIME_ZONE_ID, 1, ChronoUnit.WEEKS);
+        final Instant expected = ZonedDateTime
+            .ofInstant(instant, TIME_ZONE_ID.toZoneId())
+            .plus(1, ChronoUnit.WEEKS)
+            .toInstant();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void itShouldAddYears() throws Exception {
+        final Instant instant = Instant.now();
+        final Instant result = InstantTruncator.plus(instant, TIME_ZONE_ID, 1, ChronoUnit.YEARS);
+        final Instant expected = ZonedDateTime
+            .ofInstant(instant, TIME_ZONE_ID.toZoneId())
+            .plus(1, ChronoUnit.YEARS)
+            .toInstant();
+        assertEquals(expected, result);
+    }
+
+}


### PR DESCRIPTION
 `InstantTruncator`:
Unfortunately, the new java.time API doesn't allow for truncating units
larger than days, which is a show stopper for quite a few business
problems.

This utility class simply mimics the truncation behaviour of the
`CalendarTruncator` in the toolbox: just wrapping around an `Instant`
instead of a `Date`. Also, the `plus` and `minus` methods of `Instant`
also doesn't allow for units larger than a 24H, so those are added as
well for utility (so that the caller doesn't have to convert to a
`ZonedDateTime`).


ping @softarn and @aaanders : thoughts on this approach?
