### PR TITLE
izettle-java Interval

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/Interval.java
+++ b/izettle-java/src/main/java/com/izettle/java/Interval.java
@@ -1,0 +1,110 @@
+package com.izettle.java;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represents a period on the time line between two instants. An interval will always be inclusive at the start and
+ * exclusive at the end
+ */
+public class Interval {
+
+    private final Instant start;
+    private final Instant end;
+
+    public Interval(final Instant start, final Instant end) {
+        this.start = requireNonNull(start, "Start instant cannot be null");
+        this.end = requireNonNull(end, "End instant cannot be null");
+        if (end.isBefore(start)) {
+            throw new IllegalArgumentException("An interval cannot have an end that's before it's start");
+        }
+    }
+
+    /**
+     * Specifies whether the given instant is inside this interval or not.
+     * @param instant the instant to check
+     * @return true if the instant is inside the interval, otherwise false
+     */
+    public boolean contains(final Instant instant) {
+        requireNonNull(instant, "Instant cannot be null");
+        return start.equals(instant) || (instant.isAfter(start) && instant.isBefore(end));
+    }
+
+    /**
+     * Calculates the overlap between this and the other interval, and returns the result as a new Interval
+     * @param other the other interval to check overlap against, never null
+     * @return an Optional with a present value if the two intervals overlaps, or absent otherwise. Never null.
+     */
+    public Optional<Interval> overlap(final Interval other) {
+        requireNonNull(other, "Other interval cannot be null");
+        if (disjoint(other) || abuts(other)) {
+            return Optional.empty();
+        }
+        return Optional.of(
+            new Interval(
+                start.isAfter(other.start) ? start : other.start,
+                end.isBefore(other.end) ? end : other.end
+            )
+        );
+    }
+
+    /**
+     * Figures out whether the other interval abuts this interval in either end.
+     * @param other the other interval to compare with. Cannot be null
+     * @return true if this interval ends just were the other starts, or starts where the other ends. false otherwise
+     */
+    public boolean abuts(final Interval other) {
+        requireNonNull(other, "other interval cannot be null");
+        return start.equals(other.end) || other.start.equals(end);
+    }
+
+    /**
+     * Figures out whether the other interval is completely before or completely after this interval
+     * @param other the other interval to compare with. Cannot be null
+     * @return true if the other interval is completely before or completely after this interval
+    */
+    public boolean disjoint(final Interval other) {
+        requireNonNull(other, "other interval cannot be null");
+        return start.isAfter(other.end) || other.start.isAfter(end);
+    }
+
+    public Duration getDuration() {
+        return Duration.between(start, end);
+    }
+
+    public Instant getStart() {
+        return start;
+    }
+
+    public Instant getEnd() {
+        return end;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Interval other = (Interval) obj;
+        if (!this.start.equals(other.start)) {
+            return false;
+        }
+        return this.end.equals(other.end);
+    }
+
+}

--- a/izettle-java/src/test/java/com/izettle/java/IntervalTest.java
+++ b/izettle-java/src/test/java/com/izettle/java/IntervalTest.java
@@ -1,0 +1,91 @@
+package com.izettle.java;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Test;
+
+public class IntervalTest {
+
+    @Test
+    public void itShouldFigureOutAbuts() throws Exception {
+        final Instant instant1 = Instant.parse("2007-09-01T10:15:30.00Z");
+        final Instant instant2 = Instant.parse("2013-10-02T10:15:30.00Z");
+        final Instant instant3 = Instant.parse("2015-11-03T10:15:30.00Z");
+        final Instant instant4 = Instant.parse("2017-12-03T10:15:30.00Z");
+        final Interval interval1 = new Interval(instant1, instant2);
+        final Interval interval2 = new Interval(instant2, instant3);
+        final Interval interval3 = new Interval(instant3, instant4);
+        final Interval encompassing = new Interval(instant1, instant4);
+        final Interval zeroDuration = new Interval(instant1, instant1);
+        assertTrue(interval1.abuts(interval2));
+        assertTrue(interval2.abuts(interval1));
+        assertTrue(interval2.abuts(interval3));
+        assertTrue(interval3.abuts(interval2));
+        assertFalse(interval1.abuts(interval3));
+        assertFalse(interval3.abuts(interval1));
+        assertFalse(interval1.abuts(interval1));
+        assertFalse(interval1.abuts(interval3));
+        assertFalse(interval1.abuts(encompassing));
+        assertTrue(zeroDuration.abuts(zeroDuration));
+    }
+
+    @Test
+    public void itShouldFigureOutOverlaps() throws Exception {
+        final Instant instant1 = Instant.parse("2007-09-01T10:15:30.00Z");
+        final Instant instant2 = Instant.parse("2013-10-02T10:15:30.00Z");
+        final Instant instant3 = Instant.parse("2015-11-03T10:15:30.00Z");
+        final Instant instant4 = Instant.parse("2017-12-03T10:15:30.00Z");
+        final Interval interval1 = new Interval(instant1, instant2);
+        final Interval interval2 = new Interval(instant2, instant3);
+        final Interval interval3 = new Interval(instant3, instant4);
+        final Interval encompassing = new Interval(instant1, instant4);
+        final Interval zeroDuration = new Interval(instant1, instant1);
+        assertFalse(interval1.overlap(interval2).isPresent());
+        assertFalse(interval1.overlap(interval3).isPresent());
+        assertTrue(interval1.overlap(encompassing).isPresent());
+        assertFalse(interval1.overlap(zeroDuration).isPresent());
+        assertEquals(interval3, encompassing.overlap(interval3).get());
+    }
+
+    @Test
+    public void itShouldFigureOutContains() throws Exception {
+        final Instant start = Instant.now();
+        final Instant end = start.plus(Duration.ofHours(1L));
+        final Interval interval = new Interval(start, end);
+        assertFalse(interval.contains(start.minus(Duration.ofMillis(1L))));
+        assertTrue(interval.contains(start));
+        assertTrue(interval.contains(start.plus(Duration.ofMillis(1L))));
+        assertFalse(interval.contains(end.plus(Duration.ofMillis(1L))));
+        assertFalse(interval.contains(end));
+        assertTrue(interval.contains(end.minus(Duration.ofMillis(1L))));
+    }
+
+    @Test
+    public void itShouldFigureOutDisjoint() throws Exception {
+        final Instant instant1 = Instant.parse("2007-09-01T10:15:30.00Z");
+        final Instant instant2 = Instant.parse("2013-10-02T10:15:30.00Z");
+        final Instant instant3 = Instant.parse("2015-11-03T10:15:30.00Z");
+        final Instant instant4 = Instant.parse("2017-12-03T10:15:30.00Z");
+        final Interval interval1 = new Interval(instant1, instant2);
+        final Interval interval2 = new Interval(instant2, instant3);
+        final Interval interval3 = new Interval(instant3, instant4);
+        final Interval encompassing = new Interval(instant1, instant4);
+        final Interval zeroDuration = new Interval(instant1, instant1);
+        assertFalse(interval1.disjoint(interval2));
+        assertTrue(interval1.disjoint(interval3));
+        assertFalse(interval1.disjoint(encompassing));
+        assertFalse(interval1.disjoint(zeroDuration));
+    }
+
+    @Test
+    public void itShouldReturnCorrectDuration() throws Exception {
+        final Instant start = Instant.parse("2013-10-02T10:15:30.00Z");
+        final Instant end = Instant.parse("2013-10-02T10:15:31.00Z");
+        final Interval interval = new Interval(start, end);
+        assertEquals(Duration.ofSeconds(1L), interval.getDuration());
+    }
+}


### PR DESCRIPTION
Unfortunately, the java8 time API doesn't have a proper interval class.
The only such classes in standard java is `Duration` and `Period`, but
they only hold information about the length of time: not the instant on
the timeline.
So, a proper interval class should really have been part of the standard
`java.time` API.

This class does that. It's a simple class consisting of two `Instant`s.
It's start inclusive, and end exclusive. Also, it has some utility
methods, such as `overlap`, `abuts` and `contains`.

ping @nzroller : thoughts on this? I'm thinking of quite a lot of facade methods where we're passing two `Date` objects around...