### PR TITLE
Increase AWS client retry times from 3 (default) to 6.

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/AmazonSNSClientFactory.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/AmazonSNSClientFactory.java
@@ -1,13 +1,21 @@
 package com.izettle.messaging;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.services.sns.AmazonSNSAsync;
 import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import java.util.concurrent.Executors;
 
 /**
  * Factory that creates Amazon SNS clients for specific endpoints.
  */
 public class AmazonSNSClientFactory {
+
+    /**
+     * Client configuration factory providing ClientConfigurations tailored to this client
+     */
+    private static final ClientConfigurationFactory CONFIG_FACTORY = new ClientConfigurationFactory();
 
     /**
      * Creates Amazon SNS client for given endpoint using the provided credentials.
@@ -51,10 +59,13 @@ public class AmazonSNSClientFactory {
      * @return Amazon SNS client.
      */
     private static AmazonSNSAsync createInstance(AWSCredentials awsCredentials) {
+        // default is 3 retries
+        ClientConfiguration clientConfiguration = CONFIG_FACTORY.getConfig().withMaxErrorRetry(6);
         if (awsCredentials == null) {
-            return new AmazonSNSAsyncClient();
+            return new AmazonSNSAsyncClient(clientConfiguration);
         } else {
-            return new AmazonSNSAsyncClient(awsCredentials);
+            // 50 is copied from AmazonSNSAsyncClient.DEFAULT_THREAD_POOL_SIZE
+            return new AmazonSNSAsyncClient(awsCredentials, clientConfiguration, Executors.newFixedThreadPool(50));
         }
     }
 }

--- a/izettle-messaging/src/main/java/com/izettle/messaging/AmazonSQSClientFactory.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/AmazonSQSClientFactory.java
@@ -1,13 +1,21 @@
 package com.izettle.messaging;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import java.util.concurrent.Executors;
 
 /**
  * Factory that creates Amazon SQS clients for specific endpoints.
  */
 public class AmazonSQSClientFactory {
+
+    /**
+     * Client configuration factory providing ClientConfigurations tailored to this client
+     */
+    private static final ClientConfigurationFactory CONFIG_FACTORY = new ClientConfigurationFactory();
 
     /**
      * Creates Amazon SQS client for given endpoint using the provided credentials.
@@ -51,10 +59,13 @@ public class AmazonSQSClientFactory {
      * @return Amazon SQS client.
      */
     private static AmazonSQSAsync createInstance(AWSCredentials awsCredentials) {
+        // default is 3 retries
+        ClientConfiguration clientConfiguration = CONFIG_FACTORY.getConfig().withMaxErrorRetry(6);
         if (awsCredentials == null) {
-            return new AmazonSQSAsyncClient();
+            return new AmazonSQSAsyncClient(clientConfiguration);
         } else {
-            return new AmazonSQSAsyncClient(awsCredentials);
+            // 50 is copied from AmazonSQSAsyncClient.DEFAULT_THREAD_POOL_SIZE
+            return new AmazonSQSAsyncClient(awsCredentials, clientConfiguration, Executors.newFixedThreadPool(50));
         }
     }
 }


### PR DESCRIPTION
For discussion: let's increase the retry time from 3 to 6, see if it helps? 

I searched for `MessagingManager NOT INFO` in Splunk for last 30 days, no results...

Ping @nzroller and @fredrikbackstrom, thanks...