### PR TITLE
Also remove SNS envelope from msgs produced by `wrapInSNSMessage`

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/serialization/MessageDeserializer.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/serialization/MessageDeserializer.java
@@ -46,7 +46,7 @@ public class MessageDeserializer<M> {
     public static String removeSnsEnvelope(String message) throws IOException {
         if (!empty(message) && message.startsWith("{")) {
             JsonNode root = JSON_MAPPER.readTree(message);
-            if (root.has("TopicArn") && root.has("Message")) {
+            if (root.has("Subject") && root.has("Message")) {
                 return root.get("Message").asText();
             }
         }

--- a/izettle-messaging/src/test/java/com/izettle/messaging/TestMessage.java
+++ b/izettle-messaging/src/test/java/com/izettle/messaging/TestMessage.java
@@ -1,5 +1,8 @@
 package com.izettle.messaging;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TestMessage {
     private String message;
 

--- a/izettle-messaging/src/test/resources/example-message-sent-with-messagepublisher-through-sns.json
+++ b/izettle-messaging/src/test/resources/example-message-sent-with-messagepublisher-through-sns.json
@@ -1,0 +1,12 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "d39afcae-bcf5-5303-a9f3-b35b19f37c8f",
+  "TopicArn" : "arn:aws:sns:eu-west-1:111111111111:test",
+  "Subject" : "TestMessage",
+  "Message" : "{\"amount\":3135,\"message\":\"MessagePublisher to SNS\"}",
+  "Timestamp" : "2016-07-05T12:06:30.548Z",
+  "SignatureVersion" : "1",
+  "Signature" : "f6FZfQE7gbrWVYccu5x/ipH6GT9ygcWlwU6IWdWM9BEjvn2XwjB/I4IYxnvIOQLIZSL+XgE9ABkTM1N3tXksyE7+6JrlGt8/4+xijTq1aEqhwtpCNEVHsV3glafFhdVSK+o+mZ28SikbmWVrMtWRwPq1GfgsA3R+2aZb8y3PhnSDAW6PJmwp4R/0IYTRbaU2qaMaHdn2oJYCo9HIZGjP32jzT+1rDjyKQQLkJH4slW1LHBoVbR+ij4mqm2w0g9oDl7J8GhqiID6hJG6GZOVSU9U5FzPEN8PY18MltsAHuT/HqwTkD8CDGv9Bhf4NkD/mAQ2AKkdtAy4K7cR2bYVN/w==",
+  "SigningCertURL" : "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-bb750dd426d95ee9390147a5624348ee.pem",
+  "UnsubscribeURL" : "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:111111111111:test:dbf92bfa-95fa-4f6e-b166-72af43466725"
+}

--- a/izettle-messaging/src/test/resources/example-message-sent-with-messagepublisher-to-sqs.json
+++ b/izettle-messaging/src/test/resources/example-message-sent-with-messagepublisher-to-sqs.json
@@ -1,0 +1,1 @@
+{"Message":"{\"amount\":3133,\"message\":\"MessagePublisher to SQS\"}","Subject":"TestMessage"}

--- a/izettle-messaging/src/test/resources/example-message-sent-with-messagequeueproducer-to-sqs.json
+++ b/izettle-messaging/src/test/resources/example-message-sent-with-messagequeueproducer-to-sqs.json
@@ -1,0 +1,1 @@
+{"amount":3134,"message":"MessageQueueProducer to SQS"}


### PR DESCRIPTION
* Makes the method `MessageDeserializer::removeSnsEnvelope` also remove SNS envelopes from messages that are produced by `QueueServiceSender::wrapInSNSMessage`.
* With this change, messages that are produced by either "regular" SNS publishing, directly to SQS by using `MessagePublisher`, and raw messages sent by `MessageQueueProducer`, will now all be correctly deserialized when being processed by a `MessageHandler`. Previously, messages sent directly to SQS by using `MessagePublisher` would not have their SNS envelopes removed when being handled by a `QueueServicePoller`.