### PR TITLE
Register ParameterNamesModule so that @JsonCreator annotation works.

### DIFF
--- a/izettle-messaging/pom.xml
+++ b/izettle-messaging/pom.xml
@@ -57,6 +57,11 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/izettle-messaging/src/main/java/com/izettle/messaging/serialization/JsonSerializer.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/serialization/JsonSerializer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 public class JsonSerializer {
     private static final ObjectMapper JSON_MAPPER = createInstance();
@@ -13,6 +14,7 @@ public class JsonSerializer {
         result.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         result.registerModule(new JavaTimeModule());
         result.registerModule(new Jdk8Module());
+        result.registerModule(new ParameterNamesModule());
         return result;
     }
 


### PR DESCRIPTION
ParameterNamesModule enables the use of reflection when deserializing
json string. Instead of explicitly annotating with jsonparameter annoations,
you can simply use @JsonCreator annotation on the constructor.