### PR TITLE
Fix NullPointerException in toString

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/CollectionUtils.java
+++ b/izettle-java/src/main/java/com/izettle/java/CollectionUtils.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -84,6 +85,6 @@ public class CollectionUtils {
             return null;
         }
 
-        return collection.stream().map(Object::toString).collect(Collectors.joining(delimiter));
+        return collection.stream().map(Objects::toString).collect(Collectors.joining(delimiter));
     }
 }

--- a/izettle-java/src/test/java/com/izettle/java/CollectionUtilsSpec.java
+++ b/izettle-java/src/test/java/com/izettle/java/CollectionUtilsSpec.java
@@ -161,4 +161,9 @@ public class CollectionUtilsSpec {
     public void itShouldToStringNull() {
         assertNull(null, CollectionUtils.toString(null));
     }
+
+    @Test
+    public void itShouldHandleNullElements() {
+        assertEquals(null, CollectionUtils.toString(Collections.singletonList(null)), "null");
+    }
 }


### PR DESCRIPTION
Fix a `NullPointerException` that I introduced in 6e46fd2 (#190). The old code used `StringBuilder#append`, which uses `String.valueOf` to translate `null` elements to "null". The new code used `Object#toString`, which obviously throws a `NullPointerException` for `null` elements.

`Objects.toString`, like `StringBuilder#append`, uses `String.valueOf`.