### PR TITLE
Use `sqs.sendMessage` for single message instead of `postBatch`

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
@@ -19,7 +19,6 @@ import com.izettle.messaging.serialization.JsonSerializer;
 import com.izettle.messaging.serialization.MessageSerializer;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -143,7 +142,17 @@ public class QueueServiceSender<M> implements MessageQueueProducer<M>, MessagePu
      */
     @Override
     public <T> void post(T message, String eventName) throws MessagingException {
-        postBatch(Arrays.asList(message), eventName);
+        if (empty(eventName)) {
+            throw new MessagingException("Cannot publish message with empty eventName!");
+        }
+        try {
+            amazonSQS.sendMessage(
+                new SendMessageRequest()
+                    .withMessageBody(wrapInSNSMessage(message, eventName))
+            );
+        } catch (Exception e) {
+            throw new MessagingException("Failed to post message: " + message.getClass(), e);
+        }
     }
 
     /**


### PR DESCRIPTION
* Calls `sqs.sendMessage(SendMessageRequest)` when sending a single message through `QueueServiceSender`, instead of calling `sqs.sendMessageBatch` via `postBatch`
* Reason for changing is to have better handling of errors in case a single message fails.

Ping @xiaodong-izettle , how about this for solving the same issue that #192 intends to solve?