### PR TITLE
Bugfix: Specify `queueURL` when sending single sqs message

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
@@ -147,8 +147,7 @@ public class QueueServiceSender<M> implements MessageQueueProducer<M>, MessagePu
         }
         try {
             amazonSQS.sendMessage(
-                new SendMessageRequest()
-                    .withMessageBody(wrapInSNSMessage(message, eventName))
+                new SendMessageRequest(queueUrl, wrapInSNSMessage(message, eventName))
             );
         } catch (Exception e) {
             throw new MessagingException("Failed to post message: " + message.getClass(), e);


### PR DESCRIPTION
* Specify the destination queue url when sending a single message through `MessagePublisher::post`.
* If not specifying the `queueUrl`, an exception of type `com.amazonaws.services.sqs.model.QueueDoesNotExistException` will be thrown when this is called.
* Bugfix for #193 .

Ping @xiaodong-izettle 