### PR TITLE
TLVDecoder remove array alloc during recursion.

### DIFF
--- a/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
+++ b/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
@@ -176,5 +176,4 @@ public class TLVDecoderTest {
         decodedTags = dec.decode(Hex.hexToByteArray("000000DF0301FE0000000000DF0401FF000000"));
         Assert.assertEquals(2, decodedTags.size());
     }
-
 }


### PR DESCRIPTION
This PR removes the new byte array allocation during recursive
calls. It reuses the ByteBuffer when the value of a tag is a new
TLV byte array. It keeps the array allocation when the value of a
tag is _just_ a "value", this should keep array allocations at a
minimum and my very non-educated guess is that the big arrays are the
ones where the value of a tag is a TLV, maybe @oskarwiksten have some 
more insight?

It also converts some of the recursive calls into sequential calls by looping, 
not expecting wonders out of this though. 

