### PR TITLE
Re-use byte array during recursiv call

### DIFF
--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -96,25 +96,21 @@ public class TLVDecoder {
             throw new TLVException("Tag " + Hex.toHexString(tag) + " exceeds data length");
         }
 
-        byte[] value = new byte[length];
-        System.arraycopy(input, offset, value, 0, length);
-
         int tagAsInteger = TLVUtils.tagToInt(tag);
 
         if (expandTags.contains(tagAsInteger)) {
-            if (offset + value.length > input.length) {
+            if (offset + length > input.length) {
                 throw new TLVException("Expand tag " + Hex.toHexString(tag) + " is invalid, exceeds data length");
             }
-            helper(value, 0, tags);
-            if (offset + length < input.length) {
-                // There are more tags after the expander tag.
-                helper(input, offset + length, tags);
-            }
+
+            helper(input, offset, tags);
         } else {
+            byte[] value = new byte[length];
+            System.arraycopy(input, offset, value, 0, length);
+
             tags.add(new TLV(tag, lengthEncoded, value));
-            if (offset + length == input.length) {
-                // We are finished
-            } else {
+
+            if (offset + length != input.length) {
                 helper(input, offset + length, tags);
             }
         }


### PR DESCRIPTION
Use same byte array during recursive call to decrease
the number of creations. This still produces some
arrays but the guess is that it removes the creation of
the most common one.