### PR TITLE
TLVDecoder: Prevent overflowing int when parsing TLV lengths

### DIFF
--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -92,7 +92,7 @@ public class TLVDecoder {
 
         ++offset; // Now positioned at first data byte
 
-        if (offset + length > input.length) {
+        if (length > input.length - offset) {
             throw new TLVException("Tag " + Hex.toHexString(tag) + " exceeds data length");
         }
 

--- a/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
+++ b/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
@@ -1,5 +1,6 @@
 package com.izettle.tlv;
 
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -177,4 +178,36 @@ public class TLVDecoderTest {
         Assert.assertEquals(2, decodedTags.size());
     }
 
+    @Test
+    public void shouldDecodeTLVDataWithFourByteLengthOfIntMaxValue() throws Exception {
+        // Arrange
+        final byte[] tlvData = Hex.hexToByteArray("9A847FFFFFFF");
+        thrown.expect(TLVException.class);
+        thrown.expectMessage("Tag 9A exceeds data length");
+
+        // Act
+        new TLVDecoder().decode(tlvData);
+    }
+
+    @Test
+    public void shouldDecodeTLVDataWithFourByteLengthOfAlmostIntMaxValue() throws Exception {
+        // Arrange
+        final byte[] tlvData = Hex.hexToByteArray("9A847FFFFFFA");
+        thrown.expect(TLVException.class);
+        thrown.expectMessage("Tag 9A exceeds data length");
+
+        // Act
+        new TLVDecoder().decode(tlvData);
+    }
+
+    @Test
+    public void shouldThrowExceptionOnMalformedInputData() throws Exception {
+        // Arrange
+        final byte[] tlvData = Hex.hexToByteArray("6A88");
+        thrown.expect(TLVException.class);
+        thrown.expectMessage(startsWith("Malformed length"));
+
+        // Act
+        new TLVDecoder().decode(tlvData);
+    }
 }


### PR DESCRIPTION
* When checking a parsed TLV length, prevent input data from overflowing `Int.MAX_VALUE`.
* Prevents the following exception (as can be seen when running the unit-test `shouldDecodeTLVDataWithFourByteLengthOfAlmostIntMaxValue` added in this commit):

```
Stacktrace was: java.lang.OutOfMemoryError: Java heap space
	at com.izettle.tlv.TLVDecoder.helper(TLVDecoder.java:99)
	at com.izettle.tlv.TLVDecoder.decode(TLVDecoder.java:35)
	at com.izettle.tlv.TLVDecoderTest.shouldDecodeTLVDataWithFourByteLengthOfAlmostIntMaxValue(TLVDecoderTest.java:200)
```

Ping @linnie @xiaodong-izettle 