### PR TITLE
TLVDecoder: Throw when parsing negative TLV lengths

### DIFF
--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -92,6 +92,9 @@ public class TLVDecoder {
 
         ++offset; // Now positioned at first data byte
 
+        if (length < 0) {
+            throw new TLVException("Length of tag " + Hex.toHexString(tag) + " is negative");
+        }
         if (length > input.length - offset) {
             throw new TLVException("Tag " + Hex.toHexString(tag) + " exceeds data length");
         }

--- a/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
+++ b/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
@@ -201,6 +201,17 @@ public class TLVDecoderTest {
     }
 
     @Test
+    public void shouldDecodeTLVDataWithFourByteLengthThatOverflowsIntMaxValueToMinusOne() throws Exception {
+        // Arrange
+        final byte[] tlvData = Hex.hexToByteArray("9A84FFFFFFFF");
+        thrown.expect(TLVException.class);
+        thrown.expectMessage("Length of tag 9A is negative");
+
+        // Act
+        new TLVDecoder().decode(tlvData);
+    }
+
+    @Test
     public void shouldThrowExceptionOnMalformedInputData() throws Exception {
         // Arrange
         final byte[] tlvData = Hex.hexToByteArray("6A88");


### PR DESCRIPTION
* Throw `TLVException` when parsing TLV data that specifies a negative length.
* Prevents the following exception, as can be seen when runnin ght unit-test `shouldDecodeTLVDataWithFourByteLengthThatOverflowsIntMaxValueToMinusOne` added in this commit):
```
Stacktrace was: java.lang.NegativeArraySizeException
	at com.izettle.tlv.TLVDecoder.helper(TLVDecoder.java:99)
	at com.izettle.tlv.TLVDecoder.decode(TLVDecoder.java:35)
	at com.izettle.tlv.TLVDecoderTest.shouldDecodeTLVDataWithFourByteLengthThatOverflowsIntMaxValueToMinusOne(TLVDecoderTest.java:189)
```

Ping @linnie 