### PR TITLE
Use default consistency level

### DIFF
--- a/izettle-dropwizard/src/main/java/com/izettle/dropwizard/cassandra/CassandraSessionFactory.java
+++ b/izettle-dropwizard/src/main/java/com/izettle/dropwizard/cassandra/CassandraSessionFactory.java
@@ -1,10 +1,8 @@
 package com.izettle.dropwizard.cassandra;
 
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.PoolingOptions;
-import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.policies.ConstantSpeculativeExecutionPolicy;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
@@ -62,7 +60,6 @@ public class CassandraSessionFactory {
             .setConnectionsPerHost(HostDistance.REMOTE, 1, 2);
         final Cluster cluster = Cluster
             .builder()
-            .withQueryOptions(new QueryOptions().setConsistencyLevel(ConsistencyLevel.ONE))
             .withRetryPolicy(DefaultRetryPolicy.INSTANCE)
             .withReconnectionPolicy(new ExponentialReconnectionPolicy(10L, 1000L))
             .withLoadBalancingPolicy(new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().build()))

--- a/izettle-dropwizard/src/main/java/com/izettle/dropwizard/cassandra/CassandraSessionFactory.java
+++ b/izettle-dropwizard/src/main/java/com/izettle/dropwizard/cassandra/CassandraSessionFactory.java
@@ -55,14 +55,22 @@ public class CassandraSessionFactory {
     }
 
     public CassandraSessionManaged build(Environment environment) {
+        return build(environment, null);
+    }
+
+    public CassandraSessionManaged build(Environment environment, String localDc) {
         PoolingOptions poolingOptions = new PoolingOptions();
         poolingOptions.setConnectionsPerHost(HostDistance.LOCAL,  3, 5)
             .setConnectionsPerHost(HostDistance.REMOTE, 1, 2);
+        final DCAwareRoundRobinPolicy.Builder builder = DCAwareRoundRobinPolicy.builder();
+        if (localDc != null) {
+            builder.withLocalDc(localDc);
+        }
         final Cluster cluster = Cluster
             .builder()
             .withRetryPolicy(DefaultRetryPolicy.INSTANCE)
             .withReconnectionPolicy(new ExponentialReconnectionPolicy(10L, 1000L))
-            .withLoadBalancingPolicy(new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().build()))
+            .withLoadBalancingPolicy(new TokenAwarePolicy(builder.build()))
             .addContactPoints(getContactPoints().stream().toArray(String[]::new))
             .withPort(getPort())
             .withSpeculativeExecutionPolicy(new ConstantSpeculativeExecutionPolicy(1000, 2))


### PR DESCRIPTION
The default consistency level from the driver is good enough for us... 

Also adding support to set `localDc` when creating cluster object...

Ping @x1a0, thanks...