### PR TITLE
Refactor to use minimal ELB interface to AWS

### DIFF
--- a/izettle-java-alb/pom.xml
+++ b/izettle-java-alb/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
-            <version>1.0.3</version>
+            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/izettle-java-alb/src/main/java/com/izettle/alb/ALBAvailableInstancesCondition.java
+++ b/izettle-java-alb/src/main/java/com/izettle/alb/ALBAvailableInstancesCondition.java
@@ -2,7 +2,7 @@ package com.izettle.alb;
 
 import static java.util.Objects.requireNonNull;
 
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient;
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult;
 import java.util.concurrent.CompletableFuture;
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
  */
 public class ALBAvailableInstancesCondition implements Condition {
 
-    private final AmazonElasticLoadBalancingClient elbClient;
+    private final AmazonElasticLoadBalancing elb;
     private final String targetGroupArn;
     private final int minNumberOfAvailableInstances;
     private final int maxNumberOfAvailableInstances;
@@ -23,7 +23,7 @@ public class ALBAvailableInstancesCondition implements Condition {
     private final String instanceId;
 
     public ALBAvailableInstancesCondition(
-        AmazonElasticLoadBalancingClient elbClient,
+        AmazonElasticLoadBalancing elb,
         String targetGroupArn,
         String instanceId,
         int minNumberOfAvailableInstances,
@@ -31,7 +31,7 @@ public class ALBAvailableInstancesCondition implements Condition {
         long millisToSleepBetweenConditionCheck
     ) {
 
-        requireNonNull(elbClient);
+        requireNonNull(elb);
         requireNonNull(targetGroupArn);
         requireNonNull(instanceId);
 
@@ -41,7 +41,7 @@ public class ALBAvailableInstancesCondition implements Condition {
         this.maxNumberOfAvailableInstances = maxNumberOfAvailableInstances;
 
         this.targetGroupArn = targetGroupArn;
-        this.elbClient = elbClient;
+        this.elb = elb;
     }
 
     @Override
@@ -56,7 +56,7 @@ public class ALBAvailableInstancesCondition implements Condition {
 
                     // First await that there are enough instances available
                     DescribeTargetHealthResult describeTargetHealthResult =
-                        elbClient.describeTargetHealth(new DescribeTargetHealthRequest().withTargetGroupArn(
+                        elb.describeTargetHealth(new DescribeTargetHealthRequest().withTargetGroupArn(
                             targetGroupArn));
 
                     // Number of healthy instances other than ourselves

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 
         <assertj-core.version>3.4.1</assertj-core.version>
         <astyanax.version>3.9.0</astyanax.version>
-        <aws.version>1.11.73</aws.version>
+        <aws.version>1.11.78</aws.version>
         <bouncycastle.version>1.55</bouncycastle.version>
         <cassandra-unit.version>3.0.0.1</cassandra-unit.version>
         <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>


### PR DESCRIPTION
Instead of using the `AmazonElasticLoadBalancingClient`, the `AmazonElasticLoadBalancing` interface is used instead, which allows the user to build such an implementation using
```
AmazonElasticLoadBalancingClientBuilder.defaultClient();
```
which'll utilise any instance profiles and the region of the instance. 

@danizettle 