### PR TITLE
Instant serializer: Add test verifying presence of ms

### DIFF
--- a/izettle-jackson/src/test/java/com/izettle/jackson/module/InstantRFC3339ModuleTest.java
+++ b/izettle-jackson/src/test/java/com/izettle/jackson/module/InstantRFC3339ModuleTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.junit.Test;
 
 public class InstantRFC3339ModuleTest {
@@ -19,6 +20,22 @@ public class InstantRFC3339ModuleTest {
         final ObjectMapper mapper = createMapper();
         final Instant parsedInstant = mapper.readValue("\"2016-08-04T09:42:51.336+0200\"", Instant.class);
         assertEquals(Instant.parse("2016-08-04T07:42:51.336Z"), parsedInstant);
+    }
+
+    @Test
+    public void itShouldAlwaysProduceMillis() throws Exception {
+        final ObjectMapper mapper = createMapper();
+        final Instant nowTruncatedToSeconds = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        final String actual = mapper.writeValueAsString(nowTruncatedToSeconds);
+        assertTrue(
+            String.format(
+                "Expected the output to end with millis and zero offset '000+0000', but when serializing %s the result "
+                + "was: %s",
+                nowTruncatedToSeconds,
+                actual
+            ),
+            actual.contains(".000+0000")
+        );
     }
 
     @Test


### PR DESCRIPTION
Even if the time is in even seconds.

Seems to pass. I still don't know what caused the absence of ms in our systems during the last couple of days.

Anyway, I thought that the test might be good to have in place anyway... ping @xiaodong-izettle 