### PR TITLE
INT-290: Add UUIDParamConverterProvider

### DIFF
--- a/izettle-jackson/pom.xml
+++ b/izettle-jackson/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>javax.ws.rs-api</artifactId>
             <version>${javax-ws-rs.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <version>${google-truth.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/izettle-jackson/pom.xml
+++ b/izettle-jackson/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -44,6 +45,11 @@
             <groupId>com.izettle.toolbox</groupId>
             <artifactId>izettle-java</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>${javax-ws-rs.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/izettle-jackson/src/main/java/com/izettle/jackson/paramconverter/UUIDParamConverterProvider.java
+++ b/izettle-jackson/src/main/java/com/izettle/jackson/paramconverter/UUIDParamConverterProvider.java
@@ -1,0 +1,37 @@
+package com.izettle.jackson.paramconverter;
+
+import com.izettle.java.UUIDFactory;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.UUID;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+
+/**
+ * Provides a param converter that will accept UUIDs in resource paths as either HEX or BASE-64<p>
+ *
+ * To use in a dropwizard app, register it like you would any other Jersey component.<p>
+ *
+ * <code>environment.jersey().register(new UUIDParamConverterProvider());</code>
+ */
+public class UUIDParamConverterProvider implements ParamConverterProvider {
+    @Override
+    public <T> ParamConverter<T> getConverter(
+        Class<T> rawType, Type genericType, Annotation[] annotations
+    ) {
+        if (rawType.getName().equals(UUID.class.getName())) {
+            return new ParamConverter<T>() {
+                @Override
+                public T fromString(String value) {
+                    return rawType.cast(UUIDFactory.parse(value));
+                }
+
+                @Override
+                public String toString(T value) {
+                    return value == null ? null : value.toString();
+                }
+            };
+        }
+        return null;
+    }
+}

--- a/izettle-jackson/src/test/java/com/izettle/jackson/paramconverter/UUIDParamConverterProviderTest.java
+++ b/izettle-jackson/src/test/java/com/izettle/jackson/paramconverter/UUIDParamConverterProviderTest.java
@@ -1,0 +1,40 @@
+package com.izettle.jackson.paramconverter;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.izettle.java.UUIDFactory;
+import java.util.UUID;
+import javax.ws.rs.ext.ParamConverter;
+import org.junit.Test;
+
+/**
+ * Created by mattias on 2017-03-15.
+ */
+public class UUIDParamConverterProviderTest {
+
+    private final ParamConverter<UUID> paramConverter =
+        new UUIDParamConverterProvider().getConverter(UUID.class, null, null);
+    private final UUID expectedUuid = UUIDFactory.createUUID1();
+    private final String base64String = UUIDFactory.toBase64String(expectedUuid);
+    private final String hexString = expectedUuid.toString();
+
+    @Test
+    public void testDeserializeHexUuid() {
+        UUID actualUuid = paramConverter.fromString(hexString);
+        assertThat(actualUuid).isEqualTo(expectedUuid);
+    }
+
+    @Test
+    public void testDeserializeBase64Uuid() {
+        UUID actualUuid = paramConverter.fromString(base64String);
+        assertThat(actualUuid).isEqualTo(expectedUuid);
+    }
+
+    // Serialisation is probably not used, but the functionality is there so...
+    @Test
+    public void testSerializeHexUuid() {
+        String actualString = paramConverter.toString(expectedUuid);
+        assertThat(actualString).isEqualTo(hexString);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <slf4j.version>1.7.21</slf4j.version>
         <dropwizard.version>1.0.5</dropwizard.version>
+        <javax-ws-rs.version>2.0.1</javax-ws-rs.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.izettle</groupId>
@@ -50,7 +51,7 @@
         <module>izettle-cassandra-datastax</module>
         <module>izettle-cassandra-astyanax</module>
         <module>izettle-dropwizard</module>
-		<module>izettle-java-alb</module>
+        <module>izettle-java-alb</module>
         <module>izettle-jackson</module>
     </modules>
 
@@ -74,6 +75,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <dropwizard.version>1.0.5</dropwizard.version>
         <javax-ws-rs.version>2.0.1</javax-ws-rs.version>
+        <google-truth.version>0.30</google-truth.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Add a ParamConverterProvider for UUIDS that supports both standard hex format as well as base64.

This relates to thhis PR in cashregister-service. https://github.com/iZettle/cash-register/pull/170/files

As soon as this is merged I can release and bump the version for toolbox and use it in cash-register-service.