### PR TITLE
Cart: Add test for taxable value

### DIFF
--- a/izettle-cart/src/main/java/com/izettle/cart/ItemLine.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/ItemLine.java
@@ -62,7 +62,7 @@ public class ItemLine<T extends Item<T, K>, K extends Discount<K>> implements Se
      * The value of the line before VAT has been added.
      * @return the taxable value, or the actual value if no VAT exists.
      */
-    public Long getActualTaxableValue() {
+    public long getActualTaxableValue() {
         return actualValue - coalesce(actualVat, 0L);
     }
 

--- a/izettle-cart/src/test/java/com/izettle/cart/ItemTest.java
+++ b/izettle-cart/src/test/java/com/izettle/cart/ItemTest.java
@@ -47,6 +47,42 @@ public class ItemTest {
     }
 
     @Test
+    public void testTaxableValueIsCorrect() {
+        //Arrange
+        Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> cart;
+        List<TestItem> items = new ArrayList<TestItem>();
+        items.add(new TestItem(
+            "Without VAT",
+            1000L,
+            null,
+            BigDecimal.ONE,
+            new TestDiscount(null, 50d, BigDecimal.ONE)
+        ));
+        items.add(new TestItem(
+            "With VAT",
+            1000L,
+            25f,
+            BigDecimal.ONE,
+            new TestDiscount(null, 50d, BigDecimal.ONE)
+        ));
+        List<TestDiscount> discounts = new ArrayList<TestDiscount>();
+        discounts.add(new TestDiscount(null, 20d, BigDecimal.ONE));
+
+        //Act
+        cart = new Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge>(items, discounts, null);
+
+        //Assert
+        assertEquals(800L, cart.getValue());
+        List<ItemLine<TestItem, TestDiscount>> itemLines = cart.getItemLines();
+        ItemLine<TestItem, TestDiscount> line1 = itemLines.get(0);
+        assertEquals(400L, line1.getActualValue());
+        assertEquals(400L, line1.getActualTaxableValue());
+        ItemLine<TestItem, TestDiscount> line2 = itemLines.get(1);
+        assertEquals(400L, line2.getActualValue());
+        assertEquals(320L, line2.getActualTaxableValue());
+    }
+
+    @Test
     public void testThatInverseIsCorrectWhenIncludingDiscounts() {
         List<TestItem> items;
         Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> cart;


### PR DESCRIPTION
Also change return type of `ItemLine::getActualTaxableValue` from `Long`
to `long` as it's always going to return a valid value, and the
convention in this project is to then use native types.

ping @psvanstrom 