### PR TITLE
Dependency mgmt: Exclude 3.2 from cassandra version

### DIFF
--- a/izettle-dropwizard/pom.xml
+++ b/izettle-dropwizard/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>izettle-dropwizard</artifactId>
 
 	<properties>
-		<cassandra-driver.version>[3.1,)</cassandra-driver.version>
+		<cassandra-driver.version>[3.1,3.2)</cassandra-driver.version>
 		<cassandra-unit.version>2.1.9.2</cassandra-unit.version>
 		<truth.version>0.28</truth.version>
 	</properties>


### PR DESCRIPTION
Previous maven range was open-ended and made a new version break the build. This
change simply requires the allowed version to be strictly less than 3.2