### PR TITLE
Adds support for getting the amount of VAT per unit of a line

### DIFF
--- a/izettle-cart/src/main/java/com/izettle/cart/CartUtils.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/CartUtils.java
@@ -309,8 +309,9 @@ class CartUtils {
             } else {
                 effectivePrice = ItemUtils.getValue(item);
             }
-            final Long grossVat = calculateVatFromGrossAmount(ItemUtils.getGrossValue(item), item.getVatPercentage());
-            final Long effectiveVat = calculateVatFromGrossAmount(effectivePrice, item.getVatPercentage());
+            final Long grossVat = calculateVatFromAmount(ItemUtils.getGrossValue(item), item.getVatPercentage());
+            final Long effectiveVat = calculateVatFromAmount(effectivePrice, item.getVatPercentage());
+            final Long unitVat = calculateVatFromAmount(item.getUnitPrice(), item.getVatPercentage());
 
             final ItemLine<T, K> itemLine = new ItemLine<T, K>(
                 item,
@@ -318,7 +319,8 @@ class CartUtils {
                 grossVat,
                 effectivePrice,
                 effectiveVat,
-                ItemUtils.getDiscountValue(item)
+                ItemUtils.getDiscountValue(item),
+                unitVat
             );
 
             retList.add(itemLine);
@@ -326,7 +328,7 @@ class CartUtils {
         return retList;
     }
 
-    static Long calculateVatFromGrossAmount(final Long amountIncVat, final Float vatPercent) {
+    static Long calculateVatFromAmount(final Long amountIncVat, final Float vatPercent) {
         if (amountIncVat == null || vatPercent == null) {
             return null;
         }

--- a/izettle-cart/src/main/java/com/izettle/cart/ItemLine.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/ItemLine.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
  * @param <T> The type of the Item itself
  * @param <K> The type of the optional Discount that might be associated with the provided Item
  */
-public class ItemLine<T extends Item<T, K>, K extends Discount<K>> implements Serializable{
+public class ItemLine<T extends Item<T, K>, K extends Discount<K>> implements Serializable {
 
     private static final long serialVersionUID = -6348123371367411158L;
     private final T item;
@@ -19,14 +19,24 @@ public class ItemLine<T extends Item<T, K>, K extends Discount<K>> implements Se
     private final long actualValue;
     private final Long actualVat;
     private final Long discountValue;
+    private final Long unitVat;
 
-    ItemLine(T item, long grossValue, Long grossVat, long actualValue, Long actualVat, Long discountValue) {
+    ItemLine(
+        T item,
+        long grossValue,
+        Long grossVat,
+        long actualValue,
+        Long actualVat,
+        Long discountValue,
+        Long unitVat
+    ) {
         this.item = item;
         this.grossValue = grossValue;
         this.grossVat = grossVat;
         this.actualValue = actualValue;
         this.actualVat = actualVat;
         this.discountValue = discountValue;
+        this.unitVat = unitVat;
     }
 
     /**
@@ -90,6 +100,14 @@ public class ItemLine<T extends Item<T, K>, K extends Discount<K>> implements Se
         return discountValue;
     }
 
+    /**
+     * The amount of the VAT per unit of this line.
+     * @return The amount of VAT per unit of this line.
+     */
+    public Long getUnitVat() {
+        return unitVat;
+    }
+
     @Override
     public String toString() {
         return ""
@@ -99,7 +117,9 @@ public class ItemLine<T extends Item<T, K>, K extends Discount<K>> implements Se
             + ", grossVat = " + grossVat
             + ", actualValue = " + actualValue
             + ", actualVat = " + actualVat
-            + '}';
+            + ", discountValue = " + discountValue
+            + ", unitVat = " + unitVat
+            + " }";
     }
 
 }

--- a/izettle-cart/src/test/java/com/izettle/cart/ItemTest.java
+++ b/izettle-cart/src/test/java/com/izettle/cart/ItemTest.java
@@ -80,6 +80,7 @@ public class ItemTest {
         ItemLine<TestItem, TestDiscount> line2 = itemLines.get(1);
         assertEquals(400L, line2.getActualValue());
         assertEquals(320L, line2.getActualTaxableValue());
+        assertEquals(200L, (long) line2.getUnitVat());
     }
 
     @Test


### PR DESCRIPTION
### Background
In the UK, we must, [according to law](https://www.gov.uk/vat-record-keeping/vat-invoices), list the price per item excluding VAT on invoices. The cart library today supports listing price per _line_ and price per _cart_ excluding VAT. But this is not enough for the UK. 

### What does this PR change?
This PR adds a field to the `ItemLine` class called `unitVat`. `CartUtils.buildItemLines` is modified to also put the VAT amount per unit in the line. I consider this to be the most backwards-compatible way to accomplish this.

### Could this be done in a better way?
Yes, absolutely! 
We could modify `Item` to add a default method:
```java
/**
 * Returns the VAT amount per item
 * @return
 */
default long getUnitVat() {
    return CartUtils.calculateVatFromAmount(getUnitPrice(), getVatPercentage());
}
```
But we can't do this right now, because it would break Android support.