### PR TITLE
TLV Decoder: Fail early on malformed TLV tags

### DIFF
--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -57,6 +57,9 @@ public class TLVDecoder {
              * tag. Subsequent tag bytes have 0x80 bit set.
              */
             do {
+                if (offset + 1 >= input.length) {
+                    throw new TLVException("Malformed tag, exceeds buffer size: " + Hex.toHexString(tag));
+                }
                 tag = ArrayUtils.concat(tag, new byte[]{input[++offset]});
             } while ((input[offset] & 0x80) == 0x80);
         }

--- a/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
+++ b/izettle-emv/src/test/java/com/izettle/tlv/TLVDecoderTest.java
@@ -221,4 +221,15 @@ public class TLVDecoderTest {
         // Act
         new TLVDecoder().decode(tlvData);
     }
+
+    @Test
+    public void shouldThrowExceptionOnMalformedTag() throws Exception {
+        // Arrange
+        final byte[] tlvData = Hex.hexToByteArray("FFFFFFFF");
+        thrown.expect(TLVException.class);
+        thrown.expectMessage(startsWith("Malformed tag, exceeds buffer size"));
+
+        // Act
+        new TLVDecoder().decode(tlvData);
+    }
 }


### PR DESCRIPTION
* Throw explicit `TLVException` when reading the tag would otherwise exceed the buffer length.
* Prevents the following exception (as seen in the added unit test added in this commit):
```
java.lang.ArrayIndexOutOfBoundsException: 4
	at com.izettle.tlv.TLVDecoder.helper(TLVDecoder.java:60)
	at com.izettle.tlv.TLVDecoder.decode(TLVDecoder.java:35)
	at com.izettle.tlv.TLVDecoderTest.shouldThrowExceptionOnMalformedTag(TLVDecoderTest.java:230)
```
* Reason for adding is to safeguard callers that only catch `TLVException` (and not `RuntimeException`s such as `ArrayIndexOutOfBoundsException`), so that callers also handle such malformed input correctly.

Ping @linnie 