### PR TITLE
Added AdminDirectAccessFilter to filter /admin access

### DIFF
--- a/izettle-dropwizard/pom.xml
+++ b/izettle-dropwizard/pom.xml
@@ -12,6 +12,7 @@
 
 	<properties>
 		<truth.version>0.28</truth.version>
+		<guava.version>18.0</guava.version>
 	</properties>
 
 	<dependencies>
@@ -42,6 +43,11 @@
 			<version>${jackson.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
+		</dependency>
 
 		<!-- test only -->
 		<dependency>
@@ -64,12 +70,6 @@
 			<groupId>org.cassandraunit</groupId>
 			<artifactId>cassandra-unit</artifactId>
 			<version>${cassandra-unit.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/izettle-dropwizard/src/main/java/com/izettle/dropwizard/filters/AdminDirectAccessFilter.java
+++ b/izettle-dropwizard/src/main/java/com/izettle/dropwizard/filters/AdminDirectAccessFilter.java
@@ -1,0 +1,60 @@
+package com.izettle.dropwizard.filters;
+
+import com.google.common.net.HttpHeaders;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpStatus;
+
+/**
+ * Allow access to /admin from localhost and from load balancer but not via a LB (from the outside)
+ * by denying all access where header X-ForwardedFor is set.
+ *
+ * This filter is required when running a DropWizard app on a single port for with:
+ *
+ * type: simple
+ * adminContextPath: /admin
+ *
+ */
+public class AdminDirectAccessFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            if (isAdmin(httpRequest) && !isDirectAccess(httpRequest)) {
+
+                HttpServletResponse httpResponse = (HttpServletResponse) response;
+                httpResponse.setStatus(HttpStatus.UNAUTHORIZED_401);
+                httpResponse.getWriter().print("401 Unauthorized");
+            } else {
+                chain.doFilter(request, response); // This signals that the request should pass this filter
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    boolean isAdmin(HttpServletRequest request) {
+        return request.getContextPath().startsWith("/admin");
+    }
+
+    boolean isDirectAccess(HttpServletRequest request) {
+        return request.getHeader(HttpHeaders.X_FORWARDED_FOR) == null;
+    }
+}

--- a/izettle-dropwizard/src/test/java/com/izettle/dropwizard/filters/AdminDirectAccessFilterTest.java
+++ b/izettle-dropwizard/src/test/java/com/izettle/dropwizard/filters/AdminDirectAccessFilterTest.java
@@ -1,0 +1,61 @@
+package com.izettle.dropwizard.filters;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.net.HttpHeaders;
+import java.io.PrintWriter;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Test;
+
+public class AdminDirectAccessFilterTest {
+
+    @Test
+    public void adminDirectAccessFilterShouldBlockForwardedTrafficOnAdmin() throws Exception {
+        AdminDirectAccessFilter adaFilter = new AdminDirectAccessFilter();
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        PrintWriter respWriter = mock(PrintWriter.class);
+
+        when(req.getRemoteAddr()).thenReturn("11.22.22.33");
+        when(req.getContextPath()).thenReturn("/admin");
+        when(req.getHeader(HttpHeaders.X_FORWARDED_FOR)).thenReturn("1.2.3.4");
+        when(resp.getWriter()).thenReturn(respWriter);
+
+        adaFilter.doFilter(req, resp, null);
+        verify(resp).setStatus(HttpStatus.UNAUTHORIZED_401);
+        verify(respWriter).print("401 Unauthorized");
+    }
+
+    @Test
+    public void adminDirectAccessFilterShouldAllowNonForwardedTrafficOnAdmin() throws Exception {
+        AdminDirectAccessFilter adaFilter = new AdminDirectAccessFilter();
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        FilterChain nextFilter = mock(FilterChain.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+
+        when(req.getContextPath()).thenReturn("/admin");
+        when(req.getHeader(HttpHeaders.X_FORWARDED_FOR)).thenReturn(null);
+
+        adaFilter.doFilter(req, resp, nextFilter);
+        verify(nextFilter).doFilter(req, resp);
+    }
+
+    @Test
+    public void adminDirectAccessFilterShouldAllowNonAdminTraffic() throws Exception {
+        AdminDirectAccessFilter adaFilter = new AdminDirectAccessFilter();
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        FilterChain nextFilter = mock(FilterChain.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+
+        when(req.getContextPath()).thenReturn("/something_else");
+        when(req.getHeader(HttpHeaders.X_FORWARDED_FOR)).thenReturn("1.2.3.4");
+
+        adaFilter.doFilter(req, resp, nextFilter);
+        verify(nextFilter).doFilter(req, resp);
+    }
+}


### PR DESCRIPTION
Allow access to `/admin` from localhost and from load balancer but not via a LB (from the outside)
by denying all access where header `X-ForwardedFor` is set. This filter is required when running a
DropWizard app on a single port.