### PR TITLE
Moves AdminDirectAccessFilter to izettle-filters

### DIFF
--- a/izettle-filters/pom.xml
+++ b/izettle-filters/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>izettle-toolbox</artifactId>
+        <groupId>com.izettle.toolbox</groupId>
+        <version>1.0.95-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>izettle-filters</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javax.servlet-api.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/izettle-filters/src/main/java/com/izettle/dropwizard/filters/AdminDirectAccessFilter.java
+++ b/izettle-filters/src/main/java/com/izettle/dropwizard/filters/AdminDirectAccessFilter.java
@@ -1,6 +1,5 @@
 package com.izettle.dropwizard.filters;
 
-import com.google.common.net.HttpHeaders;
 import java.io.IOException;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -10,7 +9,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.http.HttpStatus;
 
 /**
  * Allow access to /admin from localhost and from load balancer but not via a LB (from the outside)
@@ -23,6 +21,8 @@ import org.eclipse.jetty.http.HttpStatus;
  *
  */
 public class AdminDirectAccessFilter implements Filter {
+    static final int UNAUTHORIZED_401 = 401;
+    static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -37,7 +37,7 @@ public class AdminDirectAccessFilter implements Filter {
             if (isAdmin(httpRequest) && !isDirectAccess(httpRequest)) {
 
                 HttpServletResponse httpResponse = (HttpServletResponse) response;
-                httpResponse.setStatus(HttpStatus.UNAUTHORIZED_401);
+                httpResponse.setStatus(UNAUTHORIZED_401);
                 httpResponse.getWriter().print("401 Unauthorized");
             } else {
                 chain.doFilter(request, response); // This signals that the request should pass this filter
@@ -55,6 +55,6 @@ public class AdminDirectAccessFilter implements Filter {
     }
 
     boolean isDirectAccess(HttpServletRequest request) {
-        return request.getHeader(HttpHeaders.X_FORWARDED_FOR) == null;
+        return request.getHeader(X_FORWARDED_FOR) == null;
     }
 }

--- a/izettle-filters/src/test/java/com/izettle/dropwizard/filters/AdminDirectAccessFilterTest.java
+++ b/izettle-filters/src/test/java/com/izettle/dropwizard/filters/AdminDirectAccessFilterTest.java
@@ -1,15 +1,15 @@
 package com.izettle.dropwizard.filters;
 
+import static com.izettle.dropwizard.filters.AdminDirectAccessFilter.UNAUTHORIZED_401;
+import static com.izettle.dropwizard.filters.AdminDirectAccessFilter.X_FORWARDED_FOR;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.net.HttpHeaders;
 import java.io.PrintWriter;
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 
 public class AdminDirectAccessFilterTest {
@@ -23,11 +23,11 @@ public class AdminDirectAccessFilterTest {
 
         when(req.getRemoteAddr()).thenReturn("11.22.22.33");
         when(req.getContextPath()).thenReturn("/system");
-        when(req.getHeader(HttpHeaders.X_FORWARDED_FOR)).thenReturn("1.2.3.4");
+        when(req.getHeader(X_FORWARDED_FOR)).thenReturn("1.2.3.4");
         when(resp.getWriter()).thenReturn(respWriter);
 
         adaFilter.doFilter(req, resp, null);
-        verify(resp).setStatus(HttpStatus.UNAUTHORIZED_401);
+        verify(resp).setStatus(UNAUTHORIZED_401);
         verify(respWriter).print("401 Unauthorized");
     }
 
@@ -39,7 +39,7 @@ public class AdminDirectAccessFilterTest {
         HttpServletResponse resp = mock(HttpServletResponse.class);
 
         when(req.getContextPath()).thenReturn("/system");
-        when(req.getHeader(HttpHeaders.X_FORWARDED_FOR)).thenReturn(null);
+        when(req.getHeader(X_FORWARDED_FOR)).thenReturn(null);
 
         adaFilter.doFilter(req, resp, nextFilter);
         verify(nextFilter).doFilter(req, resp);
@@ -53,7 +53,7 @@ public class AdminDirectAccessFilterTest {
         HttpServletResponse resp = mock(HttpServletResponse.class);
 
         when(req.getContextPath()).thenReturn("/something_else");
-        when(req.getHeader(HttpHeaders.X_FORWARDED_FOR)).thenReturn("1.2.3.4");
+        when(req.getHeader(X_FORWARDED_FOR)).thenReturn("1.2.3.4");
 
         adaFilter.doFilter(req, resp, nextFilter);
         verify(nextFilter).doFilter(req, resp);

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <module>izettle-jdbi</module>
         <module>izettle-cassandra-datastax</module>
         <module>izettle-cassandra-astyanax</module>
-        <module>izettle-dropwizard</module>
+        <module>izettle-filters</module>
         <module>izettle-java-alb</module>
         <module>izettle-jackson</module>
     </modules>
@@ -77,6 +77,7 @@
         <dropwizard.version>1.0.5</dropwizard.version>
         <javax-ws-rs.version>2.0.1</javax-ws-rs.version>
         <google-truth.version>0.30</google-truth.version>
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Moves the admin filter to a new artifact `izettle-filters` with no
dependencies except for the servlet API.

The artifact `izettle-dropwizard` will be deprecated since it is not
widely used internally at iZettle (with the exception of the admin
filter).