### PR TITLE
InstantParam and a new DateTimeFormatter for RFC3339 formats

### DIFF
--- a/izettle-jackson/pom.xml
+++ b/izettle-jackson/pom.xml
@@ -50,6 +50,14 @@
             <artifactId>javax.ws.rs-api</artifactId>
             <version>${javax-ws-rs.version}</version>
         </dependency>
+
+        <!-- To be able to test BadRequestException for instance -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${javax-ws-rs.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>

--- a/izettle-jackson/src/main/java/com/izettle/jackson/module/InstantRFC3339Module.java
+++ b/izettle-jackson/src/main/java/com/izettle/jackson/module/InstantRFC3339Module.java
@@ -1,5 +1,7 @@
 package com.izettle.jackson.module;
 
+import static com.izettle.java.DateTimeFormatters.RFC_3339_INSTANT;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -10,7 +12,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
@@ -25,13 +26,10 @@ import java.time.format.DateTimeParseException;
  */
 public class InstantRFC3339Module extends SimpleModule {
 
-    private static final DateTimeFormatter INSTANT_PARSING_FORMATTER = DateTimeFormatter
+    private static final DateTimeFormatter ZULU_OR_OFFSET_PARSER = DateTimeFormatter
         .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
-    private static final DateTimeFormatter INSTANT_PARSING_FORMATTER2 = DateTimeFormatter
+    private static final DateTimeFormatter NO_MILLIS_FALLBACK = DateTimeFormatter
         .ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
-    private static final DateTimeFormatter INSTANT_FORMATTING_FORMATTER = DateTimeFormatter
-        .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-        .withZone(ZoneId.of("UTC"));
 
     /**
      * Note: This module needs to be registered after other possible modules that might try to control `Instant`, such
@@ -51,7 +49,7 @@ public class InstantRFC3339Module extends SimpleModule {
             final JsonGenerator jsonGenerator,
             final SerializerProvider serializerProvider
         ) throws IOException, JsonProcessingException {
-            jsonGenerator.writeString(INSTANT_FORMATTING_FORMATTER.format(instant));
+            jsonGenerator.writeString(RFC_3339_INSTANT.format(instant));
         }
     }
 
@@ -64,9 +62,9 @@ public class InstantRFC3339Module extends SimpleModule {
         ) throws IOException, JsonProcessingException {
             final String value = jp.readValueAs(String.class);
             try {
-                return Instant.from(INSTANT_PARSING_FORMATTER.parse(value));
+                return Instant.from(ZULU_OR_OFFSET_PARSER.parse(value));
             } catch (DateTimeParseException e) {
-                return Instant.from(INSTANT_PARSING_FORMATTER2.parse(value));
+                return Instant.from(NO_MILLIS_FALLBACK.parse(value));
             }
         }
     }

--- a/izettle-jackson/src/main/java/com/izettle/jackson/paramconverter/InstantParam.java
+++ b/izettle-jackson/src/main/java/com/izettle/jackson/paramconverter/InstantParam.java
@@ -1,0 +1,39 @@
+package com.izettle.jackson.paramconverter;
+
+import static com.izettle.java.DateTimeFormatters.RFC_3339_INSTANT;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import javax.ws.rs.BadRequestException;
+
+/**
+ * Used as a <b>@QueryParam</b> to wrap an Instant. The URI string representation should be in RFC3339 format
+ * Can also be used with to wrap an Instant with usage in <b>@PathParam</b>
+ */
+
+public class InstantParam {
+
+    private final Instant instant;
+
+    public InstantParam(final Instant instant) {
+        this.instant = instant;
+    }
+
+    public static InstantParam valueOf(final String rfc3339DateString) throws BadRequestException {
+        try {
+            final Instant instant = RFC_3339_INSTANT.parse(rfc3339DateString, Instant::from);
+            return new InstantParam(instant);
+        } catch (final DateTimeParseException e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    public Instant getInstant() {
+        return instant;
+    }
+
+    @Override
+    public String toString() {
+        return RFC_3339_INSTANT.format(instant);
+    }
+}

--- a/izettle-jackson/src/test/java/com/izettle/jackson/paramconverter/InstantParamTest.java
+++ b/izettle-jackson/src/test/java/com/izettle/jackson/paramconverter/InstantParamTest.java
@@ -1,0 +1,52 @@
+package com.izettle.jackson.paramconverter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import javax.ws.rs.BadRequestException;
+import org.junit.Test;
+
+public class InstantParamTest {
+
+    private Instant myInstant = Instant.ofEpochMilli(1387920896123L); // 24 Dec 2013, 22:34:56.123 (UTC+1)
+
+    @Test
+    public void shouldBeAbleToSerializeAnInstant() throws Exception {
+        final String result = new InstantParam(myInstant).toString();
+        assertEquals("2013-12-24T21:34:56.123+0000", result);
+    }
+
+    @Test
+    public void shouldHavePublicStaticValueOfMetod() throws Exception {
+        final Method valueOfMethod = InstantParam.class.getMethod("valueOf", String.class);
+        assertNotNull(valueOfMethod);
+        assertTrue(Modifier.isPublic(valueOfMethod.getModifiers()));
+        assertTrue(Modifier.isStatic(valueOfMethod.getModifiers()));
+        assertEquals(InstantParam.class, valueOfMethod.getReturnType());
+    }
+
+    @Test
+    public void shouldBeAbleToDeserializeIncomingRequestParameter() throws Exception {
+        final String requestParamValue = "2013-12-24T21:34:56.123+0000";
+        final InstantParam result = InstantParam.valueOf(requestParamValue);
+
+        assertEquals(myInstant, result.getInstant());
+    }
+
+    @Test
+    public void shouldThrowWhenDeserializeFaultyRequestParameter() throws Exception {
+        final String requestParamValue = "99-12-24T21:34:56.123+0000";
+        try {
+            final InstantParam ignored = InstantParam.valueOf(requestParamValue);
+            fail("Should not have been able to parse the string: " + requestParamValue);
+        } catch (final BadRequestException ex) {
+            assertTrue(ex.getCause() instanceof DateTimeParseException);
+        }
+    }
+}

--- a/izettle-java/src/main/java/com/izettle/java/DateTimeFormatters.java
+++ b/izettle-java/src/main/java/com/izettle/java/DateTimeFormatters.java
@@ -1,0 +1,20 @@
+package com.izettle.java;
+
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeFormatters {
+
+    private static final String RFC_3339_OFFSET_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+    /**
+     * Create java.time.DateTimeFormatter commonly used when communicating with services over the internet.
+     * Has the ability to parse & format TemporalAccessors, such as java.time.Instant
+     * Will always output and parse zone with "+0000"-esque format
+     * Does _NOT_ parse the Zulu indicator!
+     * Example output: "2013-12-24T21:34:56.123+0000".
+     */
+    public static final DateTimeFormatter RFC_3339_INSTANT = DateTimeFormatter
+        .ofPattern(RFC_3339_OFFSET_FORMAT)
+        .withZone(TimeZoneId.UTC.toZoneId());
+
+}


### PR DESCRIPTION
So the need to have a way of receiving an `Instant` either via `@QueryParam` or `@PathParam` increases, so I present to you: `InstantParam`.

It's basically a wrapper around an Instant, which assumes the query string or path variable, is formatted into RFC3339 date time format.
Also added a convenience method to `DateFormatCreator` for creating a new jdk 8 `DateTimeFormatter` (instead of the old `DateFormat`), so now you can parse & format `TemporalAccessor`s!