### PR TITLE
InstantParam: Improved parsing capabilities

### DIFF
--- a/izettle-jackson/src/main/java/com/izettle/jackson/module/InstantRFC3339Module.java
+++ b/izettle-jackson/src/main/java/com/izettle/jackson/module/InstantRFC3339Module.java
@@ -1,5 +1,7 @@
 package com.izettle.jackson.module;
 
+import static com.izettle.java.DateTimeFormatters.INSTANT_WITH_NO_MILLIS_FALLBACK;
+import static com.izettle.java.DateTimeFormatters.INSTANT_WITH_ZULU_OR_OFFSET;
 import static com.izettle.java.DateTimeFormatters.RFC_3339_INSTANT;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -12,7 +14,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 /**
@@ -25,11 +26,6 @@ import java.time.format.DateTimeParseException;
  * the JaveTimeModule.
  */
 public class InstantRFC3339Module extends SimpleModule {
-
-    private static final DateTimeFormatter ZULU_OR_OFFSET_PARSER = DateTimeFormatter
-        .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
-    private static final DateTimeFormatter NO_MILLIS_FALLBACK = DateTimeFormatter
-        .ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
 
     /**
      * Note: This module needs to be registered after other possible modules that might try to control `Instant`, such
@@ -62,9 +58,9 @@ public class InstantRFC3339Module extends SimpleModule {
         ) throws IOException, JsonProcessingException {
             final String value = jp.readValueAs(String.class);
             try {
-                return Instant.from(ZULU_OR_OFFSET_PARSER.parse(value));
+                return Instant.from(INSTANT_WITH_ZULU_OR_OFFSET.parse(value));
             } catch (DateTimeParseException e) {
-                return Instant.from(NO_MILLIS_FALLBACK.parse(value));
+                return Instant.from(INSTANT_WITH_NO_MILLIS_FALLBACK.parse(value));
             }
         }
     }

--- a/izettle-jackson/src/main/java/com/izettle/jackson/paramconverter/InstantParam.java
+++ b/izettle-jackson/src/main/java/com/izettle/jackson/paramconverter/InstantParam.java
@@ -1,5 +1,7 @@
 package com.izettle.jackson.paramconverter;
 
+import static com.izettle.java.DateTimeFormatters.INSTANT_WITH_NO_MILLIS_FALLBACK;
+import static com.izettle.java.DateTimeFormatters.INSTANT_WITH_ZULU_OR_OFFSET;
 import static com.izettle.java.DateTimeFormatters.RFC_3339_INSTANT;
 
 import java.time.Instant;
@@ -21,10 +23,15 @@ public class InstantParam {
 
     public static InstantParam valueOf(final String rfc3339DateString) throws BadRequestException {
         try {
-            final Instant instant = RFC_3339_INSTANT.parse(rfc3339DateString, Instant::from);
+            final Instant instant = INSTANT_WITH_ZULU_OR_OFFSET.parse(rfc3339DateString, Instant::from);
             return new InstantParam(instant);
         } catch (final DateTimeParseException e) {
-            throw new BadRequestException(e);
+            try {
+                final Instant instant =  INSTANT_WITH_NO_MILLIS_FALLBACK.parse(rfc3339DateString, Instant::from);
+                return new InstantParam(instant);
+            } catch (final DateTimeParseException e2) {
+                throw new BadRequestException(e2);
+            }
         }
     }
 

--- a/izettle-jackson/src/test/java/com/izettle/jackson/paramconverter/InstantParamTest.java
+++ b/izettle-jackson/src/test/java/com/izettle/jackson/paramconverter/InstantParamTest.java
@@ -49,4 +49,36 @@ public class InstantParamTest {
             assertTrue(ex.getCause() instanceof DateTimeParseException);
         }
     }
+
+    @Test
+    public void shouldBeAbleToDeserializeIncomingRequestParameterWithZuluIndicator() throws Exception {
+        final String requestParamValue = "2013-12-24T21:34:56.123Z";
+        final InstantParam result = InstantParam.valueOf(requestParamValue);
+        assertEquals(myInstant, result.getInstant());
+    }
+
+    @Test
+    public void shouldBeAbleToDeserializeIncomingRequestParameterWithoutMillis() throws Exception {
+        final String requestParamValue = "2013-12-24T21:34:56+0000";
+        final InstantParam result = InstantParam.valueOf(requestParamValue);
+        final Instant expected = Instant.parse("2013-12-24T21:34:56Z");
+        assertEquals(expected, result.getInstant());
+    }
+
+    @Test
+    public void shouldBeAbleToDeserializeIncomingRequestParameterWithSomeFractionalSeconds() throws Exception {
+        final String requestParamValue = "2013-12-24T21:34:56.21+0000";
+        final InstantParam result = InstantParam.valueOf(requestParamValue);
+        final Instant expected = Instant.parse("2013-12-24T21:34:56.21Z");
+        assertEquals(expected, result.getInstant());
+    }
+
+    @Test
+    public void shouldBeAbleToDeserializeIncomingRequestParameterWithZuluIndicatorWithoutMillis() throws Exception {
+        final String requestParamValue = "2013-12-24T21:34:56Z";
+        final InstantParam result = InstantParam.valueOf(requestParamValue);
+        final Instant expected = Instant.parse("2013-12-24T21:34:56Z");
+        assertEquals(expected, result.getInstant());
+    }
+
 }

--- a/izettle-java/src/main/java/com/izettle/java/DateTimeFormatters.java
+++ b/izettle-java/src/main/java/com/izettle/java/DateTimeFormatters.java
@@ -4,17 +4,28 @@ import java.time.format.DateTimeFormatter;
 
 public class DateTimeFormatters {
 
-    private static final String RFC_3339_OFFSET_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
-
     /**
      * Create java.time.DateTimeFormatter commonly used when communicating with services over the internet.
      * Has the ability to parse & format TemporalAccessors, such as java.time.Instant
      * Will always output and parse zone with "+0000"-esque format
-     * Does _NOT_ parse the Zulu indicator!
+     * Does also parse the Zulu indicator to make life easier for some clients
      * Example output: "2013-12-24T21:34:56.123+0000".
      */
     public static final DateTimeFormatter RFC_3339_INSTANT = DateTimeFormatter
-        .ofPattern(RFC_3339_OFFSET_FORMAT)
+        .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSZ")
         .withZone(TimeZoneId.UTC.toZoneId());
+
+    /**
+     * Formatter used for parsing. Should not be used for serialization
+     */
+    public static final DateTimeFormatter INSTANT_WITH_ZULU_OR_OFFSET = DateTimeFormatter
+        .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSXX");
+
+    /**
+     * Formatter used for parsing. Should not be used for serialization
+     */
+    public static final DateTimeFormatter INSTANT_WITH_NO_MILLIS_FALLBACK = DateTimeFormatter
+        .ofPattern("uuuu-MM-dd'T'HH:mm:ssX");
+
 
 }


### PR DESCRIPTION
So that it's identical to the `InstantRFC3339Module` in the sense that
it can also:
* parse strings using the Zulu indicator
* parse strings with none or parts of fractional seconds
* use 'uuuu' (year) instead of 'yyyy' (year-of-era) for serializing the
  year

Sorry for modifying your code from yesterday @izrobin but I didn't really get your underlying reason for not making the parsing more forgiving, as in the `InstantRFC3339Module`. Making the two of them behave identical should be a goal, no?

Anyway, please have a look @izrobin 