### PR TITLE
Instants: let InstantRFC3339Module be able to parse epoch longs.

### DIFF
--- a/izettle-jackson/src/main/java/com/izettle/jackson/module/InstantRFC3339Module.java
+++ b/izettle-jackson/src/main/java/com/izettle/jackson/module/InstantRFC3339Module.java
@@ -57,10 +57,20 @@ public class InstantRFC3339Module extends SimpleModule {
             final DeserializationContext context
         ) throws IOException, JsonProcessingException {
             final String value = jp.readValueAs(String.class);
+
             try {
                 return Instant.from(INSTANT_WITH_ZULU_OR_OFFSET.parse(value));
             } catch (DateTimeParseException e) {
-                return Instant.from(INSTANT_WITH_NO_MILLIS_FALLBACK.parse(value));
+                try {
+                    return Instant.from(INSTANT_WITH_NO_MILLIS_FALLBACK.parse(value));
+                } catch (DateTimeParseException e2) {
+                    try {
+                        long timeStamp = Long.parseLong(value);
+                        return Instant.ofEpochMilli(timeStamp);
+                    } catch (NumberFormatException e3) {
+                        throw e;
+                    }
+                }
             }
         }
     }

--- a/izettle-jackson/src/test/java/com/izettle/jackson/module/InstantRFC3339ModuleTest.java
+++ b/izettle-jackson/src/test/java/com/izettle/jackson/module/InstantRFC3339ModuleTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import org.junit.Test;
@@ -67,5 +68,13 @@ public class InstantRFC3339ModuleTest {
         final String value = "\"2017-02-16T16:33:55Z\"";
         final Instant parsedInstant = mapper.readValue(value, Instant.class);
         assertEquals(Instant.parse("2017-02-16T16:33:55Z"), parsedInstant);
+    }
+
+    @Test
+    public void itShouldHandleEpochTimestamp() throws IOException {
+        final ObjectMapper mapper = createMapper();
+        final String value = "1437495773948";
+        final Instant parsedInstant = mapper.readValue(value, Instant.class);
+        assertEquals(Instant.parse("2015-07-21T16:22:53.948Z"), parsedInstant);
     }
 }


### PR DESCRIPTION
The regular Date module for jackson can parse epoch longs as a Date.
Some entities has the epoch longs as the seriliazed version. These entities wont be able to use Instants transparently if
support for parsing epoch timestamps is not added.