### PR TITLE
Cart: `getAvailableItems` now returns the full list

### DIFF
--- a/izettle-cart/src/main/java/com/izettle/cart/Cart.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/Cart.java
@@ -186,9 +186,7 @@ public class Cart<T extends Item<T, D>, D extends Discount<D>, K extends Discoun
         if (cartAfterAlterations.itemLines != null) {
             for (ItemLine<AlteredCartItem, AlteredCartDiscount> itemLine : cartAfterAlterations.itemLines) {
                 final AlteredCartItem item = itemLine.getItem();
-                if (item.getQuantity().compareTo(BigDecimal.ZERO) > 0) {
-                    alterableItems.put(item.getId(), item.getQuantity());
-                }
+                alterableItems.put(item.getId(), item.getQuantity());
             }
         }
         return alterableItems;


### PR DESCRIPTION
Even the ones with quantity zero, as this serves as a helper for client
development when presenting consumed and available items for refunds.


as discussed @vincenthauser 