### PR TITLE
BugFix: truncate to earliest Offset during DST overlap

### DIFF
--- a/izettle-java/src/test/java/com/izettle/java/InstantAdjustersTest.java
+++ b/izettle-java/src/test/java/com/izettle/java/InstantAdjustersTest.java
@@ -140,4 +140,24 @@ public class InstantAdjustersTest {
             .toInstant();
         assertThat(result).isEqualTo(expected);
     }
+
+    @Test
+    public void itShouldTruncateByMonthAcrossDstOverlapp() {
+        final ZoneId zoneId = TimeZoneId.AMERICA_SAO_PAULO.toZoneId();
+        final Instant beforeOffsetChange = Instant.parse("2017-10-15T02:38:01Z");
+        final Instant afterOffsetChange = Instant.parse("2017-10-15T20:38:01Z");
+        final Instant expectedInstant = Instant.parse("2017-10-01T03:00:00Z");
+        final Instant truncatedBeforeOffsetChange = beforeOffsetChange.with(
+            InstantAdjusters.truncationBy(
+                ChronoUnit.MONTHS,
+                zoneId
+        ));
+        final Instant truncatedAfterOffsetChange = afterOffsetChange.with(
+            InstantAdjusters.truncationBy(
+                ChronoUnit.MONTHS,
+                zoneId
+        ));
+        assertThat(truncatedBeforeOffsetChange).isEqualTo(expectedInstant);
+        assertThat(truncatedAfterOffsetChange).isEqualTo(expectedInstant);
+    }
 }


### PR DESCRIPTION
Background:
Instants that are before and after a dst overlap got truncated differently.
Basically instants that where during the overlap period got truncated to the earlier offset, and those
that were after, to a later offeset.
This will prevent this, and will only truncate to the earliest possible offset.