### PR TITLE
Introduce empty checks for primitive array types

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/ValueChecks.java
+++ b/izettle-java/src/main/java/com/izettle/java/ValueChecks.java
@@ -212,6 +212,81 @@ public class ValueChecks {
     }
 
     /**
+     * Assert that an byte array has elements; that is, it must not be
+     * {@code null} and must have at least one element.
+     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
+     * @param array the array to check
+     * @param message the exception message to use if the assertion fails
+     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
+     */
+    public static byte[] assertNotEmpty(byte[] array, String message) {
+        if (empty(array)) {
+            throw new IllegalArgumentException(message);
+        }
+        return array;
+    }
+
+    /**
+     * Assert that an char array has elements; that is, it must not be
+     * {@code null} and must have at least one element.
+     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
+     * @param array the array to check
+     * @param message the exception message to use if the assertion fails
+     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
+     */
+    public static char[] assertNotEmpty(char[] array, String message) {
+        if (empty(array)) {
+            throw new IllegalArgumentException(message);
+        }
+        return array;
+    }
+
+    /**
+     * Assert that an int array has elements; that is, it must not be
+     * {@code null} and must have at least one element.
+     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
+     * @param array the array to check
+     * @param message the exception message to use if the assertion fails
+     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
+     */
+    public static int[] assertNotEmpty(int[] array, String message) {
+        if (empty(array)) {
+            throw new IllegalArgumentException(message);
+        }
+        return array;
+    }
+
+    /**
+     * Assert that an long array has elements; that is, it must not be
+     * {@code null} and must have at least one element.
+     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
+     * @param array the array to check
+     * @param message the exception message to use if the assertion fails
+     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
+     */
+    public static long[] assertNotEmpty(long[] array, String message) {
+        if (empty(array)) {
+            throw new IllegalArgumentException(message);
+        }
+        return array;
+    }
+
+    /**
+     * Assert that an double array has elements; that is, it must not be
+     * {@code null} and must have at least one element.
+     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
+     * @param array the array to check
+     * @param message the exception message to use if the assertion fails
+     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
+     */
+    public static double[] assertNotEmpty(double[] array, String message) {
+        if (empty(array)) {
+            throw new IllegalArgumentException(message);
+        }
+        return array;
+    }
+
+    /**
      * Assert that an array is not null and has no null elements.
      * Note: Does not complain if the array is empty!
      * <pre class="code">Assert.assertNoNulls(array, "The array must have non-null elements");</pre>

--- a/izettle-java/src/main/java/com/izettle/java/ValueChecks.java
+++ b/izettle-java/src/main/java/com/izettle/java/ValueChecks.java
@@ -212,78 +212,20 @@ public class ValueChecks {
     }
 
     /**
-     * Assert that an byte array has elements; that is, it must not be
-     * {@code null} and must have at least one element.
+     * Assert that an object is not "empty". See {@link ValueChecks#empty(Object)}
+     * for definition of "empty".
      * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
-     * @param array the array to check
+     * <pre class="code">Assert.assertNotEmpty(optional, "The optional must exist");</pre>
+     * <pre class="code">Assert.assertNotEmpty(object, "The object must not be null");</pre>
+     * @param object the object to check
      * @param message the exception message to use if the assertion fails
-     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
+     * @throws IllegalArgumentException if the object is "empty"
      */
-    public static byte[] assertNotEmpty(byte[] array, String message) {
-        if (empty(array)) {
+    public static Object assertNotEmpty(Object object, String message) {
+        if (empty(object)) {
             throw new IllegalArgumentException(message);
         }
-        return array;
-    }
-
-    /**
-     * Assert that an char array has elements; that is, it must not be
-     * {@code null} and must have at least one element.
-     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
-     * @param array the array to check
-     * @param message the exception message to use if the assertion fails
-     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
-     */
-    public static char[] assertNotEmpty(char[] array, String message) {
-        if (empty(array)) {
-            throw new IllegalArgumentException(message);
-        }
-        return array;
-    }
-
-    /**
-     * Assert that an int array has elements; that is, it must not be
-     * {@code null} and must have at least one element.
-     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
-     * @param array the array to check
-     * @param message the exception message to use if the assertion fails
-     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
-     */
-    public static int[] assertNotEmpty(int[] array, String message) {
-        if (empty(array)) {
-            throw new IllegalArgumentException(message);
-        }
-        return array;
-    }
-
-    /**
-     * Assert that an long array has elements; that is, it must not be
-     * {@code null} and must have at least one element.
-     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
-     * @param array the array to check
-     * @param message the exception message to use if the assertion fails
-     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
-     */
-    public static long[] assertNotEmpty(long[] array, String message) {
-        if (empty(array)) {
-            throw new IllegalArgumentException(message);
-        }
-        return array;
-    }
-
-    /**
-     * Assert that an double array has elements; that is, it must not be
-     * {@code null} and must have at least one element.
-     * <pre class="code">Assert.assertNotEmpty(array, "The array must have elements");</pre>
-     * @param array the array to check
-     * @param message the exception message to use if the assertion fails
-     * @throws IllegalArgumentException if the object array is {@code null} or has no elements
-     */
-    public static double[] assertNotEmpty(double[] array, String message) {
-        if (empty(array)) {
-            throw new IllegalArgumentException(message);
-        }
-        return array;
+        return object;
     }
 
     /**

--- a/izettle-java/src/test/java/com/izettle/java/ValueChecksSpec.java
+++ b/izettle-java/src/test/java/com/izettle/java/ValueChecksSpec.java
@@ -216,6 +216,46 @@ public class ValueChecksSpec {
     }
 
     @Test
+    public void testNotEmptyForByteArrayMessageEmpty() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Fruitbasket must have data");
+        final byte[] fruitBasket = new byte[]{};
+        ValueChecks.assertNotEmpty(fruitBasket, "Fruitbasket must have data");
+    }
+
+    @Test
+    public void testNotEmptyForCharArrayMessageEmpty() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Letters must have content");
+        final char[] letters = new char[]{};
+        ValueChecks.assertNotEmpty(letters, "Letters must have content");
+    }
+
+    @Test
+    public void testNotEmptyForIntArrayMessageEmpty() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Ages must have elements");
+        final int[] ages = new int[]{};
+        ValueChecks.assertNotEmpty(ages, "Ages must have elements");
+    }
+
+    @Test
+    public void testNotEmptyForLongArrayMessageEmpty() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Wallet must have bills");
+        final long[] bills = new long[]{};
+        ValueChecks.assertNotEmpty(bills, "Wallet must have bills");
+    }
+
+    @Test
+    public void testNotEmptyForDoubleArrayMessageEmpty() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Percentages must have content");
+        final double[] percentages = new double[]{};
+        ValueChecks.assertNotEmpty(percentages, "Percentages must have content");
+    }
+
+    @Test
     public void testNoNullElements() {
         final String[] fruits = {"Banana", "Apple"};
         final String[] result = ValueChecks.assertNoNulls(fruits, "Fruitbasket must not contain null elements");

--- a/pom.xml
+++ b/pom.xml
@@ -19,26 +19,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>http://localhost:7070/artifactory/repo</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>snapshots</id>
-            <url>http://localhost:7070/artifactory/libs-snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <modules>
         <module>izettle-java</module>
         <module>izettle-messaging</module>


### PR DESCRIPTION
So the generic `assertNotEmpty` method doesn't work with primitive types, hence this addition.

We have a method called `boolean empty(object)` already, so let's also have this assertion method for it.

Also updated the pom to not include the dev gate repo urls