### PR TITLE
Change Object to generic T for assertNotEmpty

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/ValueChecks.java
+++ b/izettle-java/src/main/java/com/izettle/java/ValueChecks.java
@@ -221,7 +221,7 @@ public class ValueChecks {
      * @param message the exception message to use if the assertion fails
      * @throws IllegalArgumentException if the object is "empty"
      */
-    public static Object assertNotEmpty(Object object, String message) {
+    public static <T> T assertNotEmpty(T object, String message) {
         if (empty(object)) {
             throw new IllegalArgumentException(message);
         }


### PR DESCRIPTION
I messed up in my previous PR #241 ... Of course `Object` is not going to be passed into the method, but instead a generic `<T>`. Otherwise it wouldn't be useful at all.

Sorry for the inconvenience! 