### PR TITLE
Bump dependencies

### DIFF
--- a/izettle-cassandra-datastax/pom.xml
+++ b/izettle-cassandra-datastax/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>izettle-cassandra-datastax</artifactId>
 	<properties>
-		<cassandra.version>2.2.8</cassandra.version>
+		<cassandra.version>2.2.11</cassandra.version>
 	</properties>
 
 	<dependencies>

--- a/izettle-jackson/pom.xml
+++ b/izettle-jackson/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>${javax-ws-rs.version}</version>
+            <version>${jersey-common.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <maven.version.range>[3.2.3,)</maven.version.range>
         <metrics.version>3.1.2</metrics.version>
-        <mockito-all.version>1.10.19</mockito-all.version>
+        <mockito-core.version>2.12.0</mockito-core.version>
         <netty.version>4.1.17.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <dropwizard.version>1.0.5</dropwizard.version>
@@ -107,8 +107,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito-all.version}</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <assertj-core.version>3.4.1</assertj-core.version>
+        <assertj-core.version>3.8.0</assertj-core.version>
         <astyanax.version>3.9.0</astyanax.version>
         <aws.version>1.11.86</aws.version>
-        <bouncycastle.version>1.55</bouncycastle.version>
+        <bouncycastle.version>1.58</bouncycastle.version>
         <cassandra-driver.version>3.3.0</cassandra-driver.version>
         <cassandra-unit.version>2.2.2.1</cassandra-unit.version>
         <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
@@ -52,12 +52,12 @@
         <maven.version.range>[3.2.3,)</maven.version.range>
         <metrics.version>3.1.2</metrics.version>
         <mockito-all.version>1.10.19</mockito-all.version>
-        <netty.version>4.0.44.Final</netty.version>
+        <netty.version>4.1.17.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <dropwizard.version>1.0.5</dropwizard.version>
         <javax-ws-rs.version>2.0.1</javax-ws-rs.version>
         <google-truth.version>0.30</google-truth.version>
-        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+        <javax.servlet-api.version>4.0.0</javax.servlet-api.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <cassandra-unit.version>2.2.2.1</cassandra-unit.version>
         <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
         <guava.version>19.0</guava.version>
-        <jackson.version>2.8.6</jackson.version>
+        <jackson.version>2.9.2</jackson.version>
         <junit.version>4.12</junit.version>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <maven.version.range>[3.2.3,)</maven.version.range>
@@ -55,8 +55,8 @@
         <netty.version>4.1.17.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <dropwizard.version>1.0.5</dropwizard.version>
-        <javax-ws-rs.version>2.0.1</javax-ws-rs.version>
-        <google-truth.version>0.30</google-truth.version>
+        <javax-ws-rs.version>2.1</javax-ws-rs.version>
+        <google-truth.version>0.36</google-truth.version>
         <javax.servlet-api.version>4.0.0</javax.servlet-api.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
         <assertj-core.version>3.8.0</assertj-core.version>
         <astyanax.version>3.9.0</astyanax.version>
-        <aws.version>1.11.86</aws.version>
+        <aws.version>1.11.229</aws.version>
         <bouncycastle.version>1.58</bouncycastle.version>
         <cassandra-driver.version>3.3.0</cassandra-driver.version>
         <cassandra-unit.version>2.2.2.1</cassandra-unit.version>
@@ -50,14 +50,15 @@
         <junit.version>4.12</junit.version>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <maven.version.range>[3.2.3,)</maven.version.range>
-        <metrics.version>3.1.2</metrics.version>
+        <metrics.version>3.2.5</metrics.version>
         <mockito-core.version>2.12.0</mockito-core.version>
         <netty.version>4.1.17.Final</netty.version>
-        <slf4j.version>1.7.21</slf4j.version>
-        <dropwizard.version>1.0.5</dropwizard.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <dropwizard.version>1.2.0</dropwizard.version>
         <javax-ws-rs.version>2.1</javax-ws-rs.version>
         <google-truth.version>0.36</google-truth.version>
         <javax.servlet-api.version>4.0.0</javax.servlet-api.version>
+        <jersey-common.version>2.26</jersey-common.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Switched to mockito-core from legacy mockito-all

New versions

```
assertj-core.version - 3.8.0
bouncycastle.version - 1.58
netty.version - 4.1.17.Final
javax.servlet-api.version - 4.0.0
jackson.version - 2.9.2
javax-ws-rs.version - 2.1
google-truth.version - 0.36
cassandra.version - 2.2.11
aws.version - 1.11.229
metrics.version - 3.2.5
slf4j.version - 1.7.25
dropwizard.version - 1.2.0
jersey-common.version - 2.26
```