### PR TITLE
Remove @author javadoc

### DIFF
--- a/izettle-cassandra-astyanax/src/main/java/com/izettle/cassandra/AwsSecurityGroupHostSupplier.java
+++ b/izettle-cassandra-astyanax/src/main/java/com/izettle/cassandra/AwsSecurityGroupHostSupplier.java
@@ -10,8 +10,6 @@ import java.util.stream.Collectors;
  * Cassandra Astyanax Host Supplier for Multiregion AWS implementations,
  * that discovers Cassandra nodes based on a given security group
  * and returns nodes only in the current/given region.
- *
- * @author progre55
  */
 public class AwsSecurityGroupHostSupplier extends AbstractAwsSecurityGroupHostSupplier<List<Host>> {
 

--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVDecoder.java
@@ -7,7 +7,6 @@ import java.util.Set;
 
 /**
  * ISO 7816 / ASN.1 compliantish decoder.
- * @author fidde
  */
 public class TLVDecoder {
 

--- a/izettle-emv/src/main/java/com/izettle/tlv/TLVEncoder.java
+++ b/izettle-emv/src/main/java/com/izettle/tlv/TLVEncoder.java
@@ -2,7 +2,6 @@ package com.izettle.tlv;
 
 /**
  * ISO 7816 / ASN.1 compliantish encoder.
- * @author fidde
  */
 public class TLVEncoder {
 

--- a/izettle-java/src/main/java/com/izettle/java/CollectionUtils.java
+++ b/izettle-java/src/main/java/com/izettle/java/CollectionUtils.java
@@ -12,10 +12,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-/**
- *
- * @author adam
- */
 public class CollectionUtils {
     private CollectionUtils() {}
 


### PR DESCRIPTION
The @author does not really tell who is the actual creator behind the code, `git blame` is a better option.

This is the result of running the following on Linux:

    find . -type f -name '*.java' -print0 | xargs -0 perl -0777 -pi -e 's|/\*\*[\s\*]+?\@author.+?\*/\n||sg'
    find . -type f -name '*.java' -print0 | xargs -0 perl -0777 -pi -e 's|([\s\*]+?\@author.+?\n)+|\n|sg'