### PR TITLE
Removed Canada/East-Saskatchewan from TimeZoneId

### DIFF
--- a/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
+++ b/izettle-java/src/main/java/com/izettle/java/TimeZoneId.java
@@ -111,7 +111,6 @@ public enum TimeZoneId {
     AMERICA_WINNIPEG("America/Winnipeg"),
     CST6CDT("CST6CDT"),
     CANADA_CENTRAL("Canada/Central"),
-    CANADA_EAST_SASKATCHEWAN("Canada/East-Saskatchewan"),
     CANADA_SASKATCHEWAN("Canada/Saskatchewan"),
     CHILE_EASTERISLAND("Chile/EasterIsland"),
     ETC_GMT_PLUS6("Etc/GMT+6"),


### PR DESCRIPTION
It was removed from the JDK: http://mm.icann.org/pipermail/tz-announce/2017-October/000047.html

> Remove Canada/East-Saskatchewan from the 'backward' file, as it
exceeded the 14-character limit and was an unused misnomer anyway

Should be safe for us to remove as well since we haven't got any merchants in Canada.