### PR TITLE
izettle-messaging: Allow custom object mapper

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/QueueServiceSender.java
@@ -13,11 +13,9 @@ import com.amazonaws.services.sqs.model.SendMessageBatchResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.izettle.cryptography.CryptographyException;
 import com.izettle.messaging.serialization.AmazonSNSMessage;
 import com.izettle.messaging.serialization.DefaultMessageSerializer;
-import com.izettle.messaging.serialization.JsonSerializer;
 import com.izettle.messaging.serialization.MessageSerializer;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,7 +39,6 @@ public class QueueServiceSender<M> implements MessageQueueProducer<M>, MessagePu
     private final String queueUrl;
     private final AmazonSQS amazonSQS;
     private final MessageSerializer messageSerializer;
-    private final ObjectMapper jsonMapper = JsonSerializer.getInstance();
 
     public static MessagePublisher nonEncryptedMessagePublisher(
             final String queueUrl,
@@ -196,7 +193,7 @@ public class QueueServiceSender<M> implements MessageQueueProducer<M>, MessagePu
     ) throws JsonProcessingException, CryptographyException {
         String messageBody = messageSerializer.encrypt(messageSerializer.serialize(message));
         AmazonSNSMessage snsMessage = new AmazonSNSMessage(subject, messageBody);
-        return jsonMapper.writeValueAsString(snsMessage);
+        return messageSerializer.serialize(snsMessage);
     }
 
     private void sendMessageBatch(Collection<SendMessageBatchRequestEntry> messages) {

--- a/izettle-messaging/src/main/java/com/izettle/messaging/handler/MessageDispatcher.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/handler/MessageDispatcher.java
@@ -25,31 +25,54 @@ public class MessageDispatcher implements MessageHandler<Message> {
     private final MessageDeserializer<String> messageDeserializer;
     private final Map<String, ListOfMessageHandlersForType> messageHandlersPerEventName = new ConcurrentHashMap<>();
     private final List<MessageHandler<AmazonSNSMessage>> defaultMessageHandlers = new ArrayList<>();
-    private static final ObjectMapper JSON_MAPPER = JsonSerializer.getInstance();
+    private final ObjectMapper objectMapper;
 
     public static MessageDispatcher nonEncryptedMessageDispatcher() {
-        return new MessageDispatcher();
+        return nonEncryptedMessageDispatcher(JsonSerializer.getInstance());
+    }
+
+    public static MessageDispatcher nonEncryptedMessageDispatcher(ObjectMapper objectMapper) {
+        return new MessageDispatcher(objectMapper);
     }
 
     public static MessageDispatcher encryptedMessageDispatcher(byte[] privatePgpKey, final String privatePgpKeyPassphrase) throws MessagingException {
+        return encryptedMessageDispatcher(privatePgpKey, privatePgpKeyPassphrase, JsonSerializer.getInstance());
+    }
+
+    public static MessageDispatcher encryptedMessageDispatcher(
+        byte[] privatePgpKey,
+        final String privatePgpKeyPassphrase,
+        ObjectMapper objectMapper
+    ) throws MessagingException {
         if (empty(privatePgpKey) || empty(privatePgpKeyPassphrase)) {
             throw new MessagingException("Can't create encryptedMessageDispatcher with private PGP key as null or privatePgpKeyPassphrase as null");
         }
-        return new MessageDispatcher(privatePgpKey, privatePgpKeyPassphrase);
+        return new MessageDispatcher(privatePgpKey, privatePgpKeyPassphrase, objectMapper);
     }
 
-    private MessageDispatcher() {
-        this.messageDeserializer = new MessageDeserializer<>(String.class);
+
+    private MessageDispatcher(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.messageDeserializer = new MessageDeserializer<>(String.class, objectMapper);
     }
 
-    private MessageDispatcher(byte[] privatePgpKey, String privatePgpKeyPassphrase) {
-        this.messageDeserializer = new MessageDeserializer<>(String.class, privatePgpKey, privatePgpKeyPassphrase);
+    private MessageDispatcher(
+        byte[] privatePgpKey,
+        String privatePgpKeyPassphrase,
+        ObjectMapper objectMapper
+    ) {
+        this.objectMapper = objectMapper;
+        this.messageDeserializer = new MessageDeserializer<>(
+            String.class,
+            privatePgpKey,
+            privatePgpKeyPassphrase,
+            this.objectMapper
+        );
     }
 
-    private static class ListOfMessageHandlersForType<M> {
+    private class ListOfMessageHandlersForType<M> {
         private final Class<M> messageType;
         public final List<MessageHandler<M>> handlers = new ArrayList<>();
-        private static final ObjectMapper JSON_MAPPER = JsonSerializer.getInstance();
 
         ListOfMessageHandlersForType(Class<M> messageType) {
             this.messageType = messageType;
@@ -58,7 +81,7 @@ public class MessageDispatcher implements MessageHandler<Message> {
             handlers.add(handler);
         }
         public void callAllHandlers(String message) throws Exception {
-            M msg = JSON_MAPPER.readValue(message, messageType);
+            M msg = objectMapper.readValue(message, messageType);
             MessageDispatcher.callAllHandlers(handlers, msg);
         }
     }
@@ -94,7 +117,7 @@ public class MessageDispatcher implements MessageHandler<Message> {
     @Override
     public void handle(Message message) throws Exception {
         String messageBody = message.getBody();
-        AmazonSNSMessage sns = JSON_MAPPER.readValue(messageBody, AmazonSNSMessage.class);
+        AmazonSNSMessage sns = objectMapper.readValue(messageBody, AmazonSNSMessage.class);
         String decryptedMessage = messageDeserializer.decrypt(sns.getMessage());
         String eventName = sns.getSubject();
         String typeName = sns.getType();

--- a/izettle-messaging/src/main/java/com/izettle/messaging/handler/MessageHandlerForSingleMessageType.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/handler/MessageHandlerForSingleMessageType.java
@@ -1,14 +1,19 @@
 package com.izettle.messaging.handler;
 
 import com.amazonaws.services.sqs.model.Message;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.izettle.messaging.serialization.MessageDeserializer;
 
 public class MessageHandlerForSingleMessageType<M> implements MessageHandler<Message> {
     private final MessageHandler<M> actualHandler;
     private final MessageDeserializer<M> messageDeserializer;
 
-    public MessageHandlerForSingleMessageType(MessageHandler<M> actualHandler, Class<M> classType) {
-        this(actualHandler, new MessageDeserializer<>(classType));
+    public MessageHandlerForSingleMessageType(
+        MessageHandler<M> actualHandler,
+        Class<M> classType,
+        ObjectMapper objectMapper
+    ) {
+        this(actualHandler, new MessageDeserializer<>(classType, objectMapper));
     }
 
     public MessageHandlerForSingleMessageType(MessageHandler<M> actualHandler, MessageDeserializer<M> messageDeserializer) {
@@ -18,7 +23,7 @@ public class MessageHandlerForSingleMessageType<M> implements MessageHandler<Mes
 
     @Override
     public void handle(Message message) throws Exception {
-        String messageBody = MessageDeserializer.removeSnsEnvelope(message.getBody());
+        String messageBody = messageDeserializer.removeSnsEnvelope(message.getBody());
         String decryptedMessage = messageDeserializer.decrypt(messageBody);
         M msg = messageDeserializer.deserialize(decryptedMessage);
         actualHandler.handle(msg);

--- a/izettle-messaging/src/main/java/com/izettle/messaging/serialization/MessageDeserializer.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/serialization/MessageDeserializer.java
@@ -14,16 +14,23 @@ public class MessageDeserializer<M> {
 
     private final byte[] privatePgpKey;
     private final String privatePgpKeyPassphrase;
-    private static final ObjectMapper JSON_MAPPER = JsonSerializer.getInstance();
+    private final ObjectMapper objectMapper;
     private final Class<M> messageClass;
 
-    public MessageDeserializer(Class<M> messageClass, byte[] privatePgpKey, final String privatePgpKeyPassphrase) {
+    public MessageDeserializer(
+        Class<M> messageClass,
+        byte[] privatePgpKey,
+        final String privatePgpKeyPassphrase,
+        ObjectMapper objectMapper
+    ) {
         this.privatePgpKey = privatePgpKey;
         this.privatePgpKeyPassphrase = privatePgpKeyPassphrase;
         this.messageClass = messageClass;
+        this.objectMapper = objectMapper;
     }
 
-    public MessageDeserializer(Class<M> messageClass) {
+    public MessageDeserializer(Class<M> messageClass, ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
         this.privatePgpKey = null;
         this.privatePgpKeyPassphrase = null;
         this.messageClass = messageClass;
@@ -40,12 +47,12 @@ public class MessageDeserializer<M> {
     }
 
     public M deserialize(String message) throws IOException {
-        return JSON_MAPPER.readValue(message, messageClass);
+        return objectMapper.readValue(message, messageClass);
     }
 
-    public static String removeSnsEnvelope(String message) throws IOException {
+    public String removeSnsEnvelope(String message) throws IOException {
         if (!empty(message) && message.startsWith("{")) {
-            JsonNode root = JSON_MAPPER.readTree(message);
+            JsonNode root = objectMapper.readTree(message);
             if (root.has("Subject") && root.has("Message")) {
                 return root.get("Message").asText();
             }

--- a/izettle-messaging/src/test/java/com/izettle/messaging/serialization/DefaultMessageSerializerTest.java
+++ b/izettle-messaging/src/test/java/com/izettle/messaging/serialization/DefaultMessageSerializerTest.java
@@ -35,7 +35,7 @@ public class DefaultMessageSerializerTest {
         // public key exported to file by:   gpg --export --armor >pgp-example-public.key
         // private key exported to file by:  gpg --export-secret-keys --armor >pgp-example-private.key
         pgpSerializer = new DefaultMessageSerializer(ResourceUtils.getResourceAsBytes("pgp-example-public.key"));
-        pgpDeserializer = new MessageDeserializer<>(TestMessage.class, ResourceUtils.getResourceAsBytes("pgp-example-private.key"), "example");
+        pgpDeserializer = new MessageDeserializer<>(TestMessage.class, ResourceUtils.getResourceAsBytes("pgp-example-private.key"), "example", JsonSerializer.getInstance());
     }
 
     @Test


### PR DESCRIPTION
Without this, one cannot customize the object mapper at all (in a good way).
For example, one might want to register KotlinModule or reuse the main object
mapper of the application.

I've tried not to be too intrusive and not break the API, so formatting and architecture stays the same (for good and for worse).

The gist of the PR is that the following static factory methods were overloaded with an `ObjectMapper objectMapper` parameter:

 - `createQueueProcessor` (only for the single message type variants)
 - `encryptedMessageDispatcher`
 - `nonEncryptedMessageDispatcher`
 - `encryptedMessageQueueConsumer`
 - `nonEncryptedMessageQueueConsumer`

The old overloaded methods defaults to the `JsonSerializer.getInstance()` object mapper, to stay backwards compatible. I also renamed all variables called `jsonMapper` to `objectMapper`.