### PR TITLE
Add support for setting attributes on messages in SQS

### DIFF
--- a/izettle-messaging/src/main/java/com/izettle/messaging/MessagePublisher.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/MessagePublisher.java
@@ -1,8 +1,12 @@
 package com.izettle.messaging;
 
 import java.util.Collection;
+import java.util.Map;
 
 public interface MessagePublisher {
     <M> void post(M message, String eventName) throws MessagingException;
     <M> void postBatch(Collection<M> messages, String eventName) throws MessagingException;
+    default <M> void post(M message, String eventName, Map<String, String> attributes) throws MessagingException {
+        post(message, eventName);
+    }
 }

--- a/izettle-messaging/src/main/java/com/izettle/messaging/MessagePublisherWithAttributes.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/MessagePublisherWithAttributes.java
@@ -1,7 +1,0 @@
-package com.izettle.messaging;
-
-import java.util.Map;
-
-public interface MessagePublisherWithAttributes extends MessagePublisher {
-    <M> void post(M message, String eventName, Map<String, String> attributes) throws MessagingException;
-}

--- a/izettle-messaging/src/main/java/com/izettle/messaging/MessagePublisherWithAttributes.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/MessagePublisherWithAttributes.java
@@ -1,0 +1,7 @@
+package com.izettle.messaging;
+
+import java.util.Map;
+
+public interface MessagePublisherWithAttributes extends MessagePublisher {
+    <M> void post(M message, String eventName, Map<String, String> attributes) throws MessagingException;
+}

--- a/izettle-messaging/src/main/java/com/izettle/messaging/PublisherService.java
+++ b/izettle-messaging/src/main/java/com/izettle/messaging/PublisherService.java
@@ -17,17 +17,17 @@ import java.util.stream.Collectors;
 /**
  * Convenience class for using Amazon Simple Notification Service.
  */
-public class PublisherService implements MessagePublisherWithAttributes {
+public class PublisherService implements MessagePublisher {
 
     private final String topicArn;
     private final AmazonSNS amazonSNS;
     private final MessageSerializer messageSerializer;
 
-    public static MessagePublisherWithAttributes nonEncryptedPublisherService(AmazonSNS client, final String topicArn) {
+    public static MessagePublisher nonEncryptedPublisherService(AmazonSNS client, final String topicArn) {
         return PublisherService.nonEncryptedPublisherService(client, topicArn, new DefaultMessageSerializer());
     }
 
-    public static MessagePublisherWithAttributes nonEncryptedPublisherService(
+    public static MessagePublisher nonEncryptedPublisherService(
             final AmazonSNS client,
             final String topicArn,
             final MessageSerializer messageSerializer

--- a/izettle-messaging/src/test/java/com/izettle/messaging/PublisherServiceTest.java
+++ b/izettle-messaging/src/test/java/com/izettle/messaging/PublisherServiceTest.java
@@ -125,7 +125,7 @@ public class PublisherServiceTest {
 
         // Arrange
         TestMessage message = new TestMessage("ad99bb4f");
-        MessagePublisherWithAttributes publisherService = PublisherService.nonEncryptedPublisherService(snsClient, "topicArn");
+        MessagePublisher publisherService = PublisherService.nonEncryptedPublisherService(snsClient, "topicArn");
         Map<String, String> attributes = new HashMap<>();
         String key = "attr";
         String value = "value";
@@ -151,7 +151,7 @@ public class PublisherServiceTest {
         thrown.expect(MessagingException.class);
         thrown.expectMessage(startsWith("Cannot publish message with more than 10 attributes!"));
         TestMessage message = new TestMessage("ad99bb4f");
-        MessagePublisherWithAttributes publisherService = PublisherService.nonEncryptedPublisherService(snsClient, "topicArn");
+        MessagePublisher publisherService = PublisherService.nonEncryptedPublisherService(snsClient, "topicArn");
         Map<String, String> attributes = new HashMap<>();
         IntStream.range(0, 11).forEach(num-> attributes.put("attr" + num, "value" + num));
 


### PR DESCRIPTION
This PR makes it possible to set the SQS attributes on messages. The attributes can be used to filter out messages on a more granular level than messageType.

This only adds support for filtering using SQS. Adding filtering on a programatic level would require some more work as we would like to do the filtering before we read the actual message.

An example where this would be useful is if you only want to listen to purchase messages that was created for the invoice checkout method. If we from the purchase service set an attribute called `checkout-method=invoice` the invoice-service could terraform to only listen to purchase messages that has that attribute/value combination on them - thus limiting the noise in the message handler.  

From the AWS doc:
Amazon SQS provides support for message attributes. Message attributes allow you to provide structured metadata items (such as timestamps, geospatial data, signatures, and identifiers) about the message. Message attributes are optional and separate from, but sent along with, the message body. This information can be used by the consumer of the message to help decide how to handle the message without having to first process the message body. Each message can have up to 10 attributes. To specify message attributes, you can use the AWS Management Console, AWS software development kits (SDKs), or Query API.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html

Filtering:
https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html

