### PR TITLE
Moving data migration framework from Authentication Service code base.

### DIFF
--- a/izettle-cart/pom.xml
+++ b/izettle-cart/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
 
     <artifactId>izettle-cart</artifactId>

--- a/izettle-cart/pom.xml
+++ b/izettle-cart/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
 
     <artifactId>izettle-cart</artifactId>

--- a/izettle-cassandra-astyanax/pom.xml
+++ b/izettle-cassandra-astyanax/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114</version>
+		<version>1.0.115-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/izettle-cassandra-astyanax/pom.xml
+++ b/izettle-cassandra-astyanax/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114-SNAPSHOT</version>
+		<version>1.0.114</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/izettle-cassandra-datastax/pom.xml
+++ b/izettle-cassandra-datastax/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114</version>
+		<version>1.0.115-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/izettle-cassandra-datastax/pom.xml
+++ b/izettle-cassandra-datastax/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114-SNAPSHOT</version>
+		<version>1.0.114</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/izettle-cassandra/pom.xml
+++ b/izettle-cassandra/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114</version>
+		<version>1.0.115-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>izettle-cassandra</artifactId>

--- a/izettle-cassandra/pom.xml
+++ b/izettle-cassandra/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114-SNAPSHOT</version>
+		<version>1.0.114</version>
 	</parent>
 
 	<artifactId>izettle-cassandra</artifactId>

--- a/izettle-cryptography/pom.xml
+++ b/izettle-cryptography/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
 
     <artifactId>izettle-cryptography</artifactId>

--- a/izettle-cryptography/pom.xml
+++ b/izettle-cryptography/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
 
     <artifactId>izettle-cryptography</artifactId>

--- a/izettle-data-migrator/data-migrator-cassandra-datastax/pom.xml
+++ b/izettle-data-migrator/data-migrator-cassandra-datastax/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.izettle.toolbox</groupId>
 		<artifactId>izettle-data-migrator</artifactId>
-		<version>1.0.114-SNAPSHOT</version>
+		<version>1.0.114</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>data-migrator-cassandra-datastax</artifactId>

--- a/izettle-data-migrator/data-migrator-cassandra-datastax/pom.xml
+++ b/izettle-data-migrator/data-migrator-cassandra-datastax/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.izettle.toolbox</groupId>
 		<artifactId>izettle-data-migrator</artifactId>
-		<version>1.0.114</version>
+		<version>1.0.115-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>data-migrator-cassandra-datastax</artifactId>

--- a/izettle-data-migrator/data-migrator-cassandra-datastax/pom.xml
+++ b/izettle-data-migrator/data-migrator-cassandra-datastax/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>com.izettle.toolbox</groupId>
+		<artifactId>izettle-data-migrator</artifactId>
+		<version>1.0.114-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>data-migrator-cassandra-datastax</artifactId>
+	<description>Cassandra DataStax Driver-based extensions to the Data Migrator Framework</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.izettle.toolbox</groupId>
+			<artifactId>data-migrator-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.izettle.toolbox</groupId>
+			<artifactId>izettle-cassandra-datastax</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/izettle-data-migrator/data-migrator-cassandra-datastax/src/main/java/com/izettle/data/migrator/cassandra/datastax/AbstractDataStaxDataMigrator.java
+++ b/izettle-data-migrator/data-migrator-cassandra-datastax/src/main/java/com/izettle/data/migrator/cassandra/datastax/AbstractDataStaxDataMigrator.java
@@ -1,0 +1,127 @@
+package com.izettle.data.migrator.cassandra.datastax;
+
+import static java.util.stream.Collectors.toList;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.izettle.data.migrator.core.BatchDataMigrator;
+import com.izettle.data.migrator.core.BatchSupportedDao;
+import com.izettle.data.migrator.core.DataMigrator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for {@link DataMigrator} that migrate Object to a Cassandra database using the
+ * DataStax driver.
+ *
+ * This implementation expects the user to provide a POJO of type {@link T} for migration.
+ * It does not specify how the POJO is obtained from the old database.
+ *
+ * @param <T> type of object to be migrated
+ */
+public abstract class AbstractDataStaxDataMigrator<T>
+    implements DataMigrator<T, BoundStatement> {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    protected final Session session;
+
+    public AbstractDataStaxDataMigrator(Session session) {
+        this.session = session;
+    }
+
+    /**
+     * Adapt this DataMigrator into a {@link BatchDataMigrator}.
+     * <p/>
+     * This allows any implementation of a simple {@link AbstractDataStaxDataMigrator} to support batch
+     * migrations automatically.
+     *
+     * @param dao DAO where records to be migrated can be fetched from
+     * @param parameters batch migrator parameters
+     * @return a batch data migrator adapted from this simple migrator
+     */
+    public BatchDataMigrator<T, List<BoundStatement>> toBatchDataMigrator(
+        BatchSupportedDao<T> dao,
+        CassandraDataStaxMigratorParameters parameters
+    ) {
+        return new BatchDataMigrator<T, List<BoundStatement>>(getClass().getSimpleName(),
+            dao, parameters.getBatchSize(), parameters.getMaxThreads()
+        ) {
+            @Override
+            public Optional<List<BoundStatement>> transform(List<T> batch) {
+                return Optional.of(batch.stream()
+                    .map(AbstractDataStaxDataMigrator.this::transform)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(toList()));
+            }
+
+            @Override
+            public void execute(List<BoundStatement> boundStatements) {
+                List<ResultSetFuture> futures = new ArrayList<>(boundStatements.size());
+                for (BoundStatement statement : boundStatements) {
+                    ResultSetFuture future = session.executeAsync(statement);
+                    futures.add(future);
+                }
+
+                // wait for all statements to be processed
+                for (ResultSetFuture future : futures) {
+                    future.getUninterruptibly();
+                }
+            }
+
+            @Override
+            protected void migrateSingleItem(T from) throws InterruptedException {
+                // use the enveloping, single-item migration - do not use migrate() as it runs asynchronously
+                AbstractDataStaxDataMigrator.this.transform(from).ifPresent(AbstractDataStaxDataMigrator.this::execute);
+            }
+
+            @Override
+            public boolean isMigrated(List<T> batch) {
+                if (parameters.getRowsToVerifyPerBatch() < 1) {
+                    return true;
+                }
+
+                // randomly select rows from the batch and check only those
+                List<T> randomOrderBatch = new ArrayList<>(batch);
+                Collections.shuffle(randomOrderBatch);
+                return randomOrderBatch.stream()
+                    .limit(parameters.getRowsToVerifyPerBatch())
+                    .allMatch(AbstractDataStaxDataMigrator.this::isMigrated);
+            }
+        };
+    }
+
+    @Override
+    public void execute(BoundStatement statement) {
+        session.execute(statement);
+    }
+
+    @Override
+    public void executeAsync(BoundStatement statement) {
+        Futures.addCallback(
+            session.executeAsync(statement),
+            new FutureCallback<ResultSet>() {
+                @Override
+                public void onSuccess(ResultSet rows) {
+                    log.debug("Successfully migrated a record");
+                }
+
+                @Override
+                public void onFailure(Throwable throwable) {
+                    log.error("Failed to execute statement to migrate a record", throwable);
+                    log.error("Failed statement: {}", statement);
+                }
+            }
+        );
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-cassandra-datastax/src/main/java/com/izettle/data/migrator/cassandra/datastax/CassandraDataStaxMigratorParameters.java
+++ b/izettle-data-migrator/data-migrator-cassandra-datastax/src/main/java/com/izettle/data/migrator/cassandra/datastax/CassandraDataStaxMigratorParameters.java
@@ -1,0 +1,40 @@
+package com.izettle.data.migrator.cassandra.datastax;
+
+import com.datastax.driver.core.Session;
+
+public class CassandraDataStaxMigratorParameters {
+
+    private final Session cassandraSession;
+    private final int batchSize;
+    private final int maxThreads;
+    private final int rowsToVerifyPerBatch;
+
+    public CassandraDataStaxMigratorParameters(
+        final Session cassandraSession,
+        final int batchSize,
+        final int maxThreads,
+        final int rowsToVerifyPerBatch
+    ) {
+        this.cassandraSession = cassandraSession;
+        this.batchSize = batchSize;
+        this.maxThreads = maxThreads;
+        this.rowsToVerifyPerBatch = rowsToVerifyPerBatch;
+    }
+
+    public Session getCassandraSession() {
+        return cassandraSession;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public int getMaxThreads() {
+        return maxThreads;
+    }
+
+    public int getRowsToVerifyPerBatch() {
+        return rowsToVerifyPerBatch;
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-cassandra-datastax/src/main/java/com/izettle/data/migrator/cassandra/datastax/CassandraDataStaxMigratorParameters.java
+++ b/izettle-data-migrator/data-migrator-cassandra-datastax/src/main/java/com/izettle/data/migrator/cassandra/datastax/CassandraDataStaxMigratorParameters.java
@@ -1,28 +1,19 @@
 package com.izettle.data.migrator.cassandra.datastax;
 
-import com.datastax.driver.core.Session;
-
 public class CassandraDataStaxMigratorParameters {
 
-    private final Session cassandraSession;
     private final int batchSize;
     private final int maxThreads;
     private final int rowsToVerifyPerBatch;
 
     public CassandraDataStaxMigratorParameters(
-        final Session cassandraSession,
         final int batchSize,
         final int maxThreads,
         final int rowsToVerifyPerBatch
     ) {
-        this.cassandraSession = cassandraSession;
         this.batchSize = batchSize;
         this.maxThreads = maxThreads;
         this.rowsToVerifyPerBatch = rowsToVerifyPerBatch;
-    }
-
-    public Session getCassandraSession() {
-        return cassandraSession;
     }
 
     public int getBatchSize() {

--- a/izettle-data-migrator/data-migrator-core/pom.xml
+++ b/izettle-data-migrator/data-migrator-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.izettle.toolbox</groupId>
 		<artifactId>izettle-data-migrator</artifactId>
-		<version>1.0.114</version>
+		<version>1.0.115-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>data-migrator-core</artifactId>

--- a/izettle-data-migrator/data-migrator-core/pom.xml
+++ b/izettle-data-migrator/data-migrator-core/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>com.izettle.toolbox</groupId>
+		<artifactId>izettle-data-migrator</artifactId>
+		<version>1.0.114-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>data-migrator-core</artifactId>
+	<description>Core module of the Data Migrator Framework</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/izettle-data-migrator/data-migrator-core/pom.xml
+++ b/izettle-data-migrator/data-migrator-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.izettle.toolbox</groupId>
 		<artifactId>izettle-data-migrator</artifactId>
-		<version>1.0.114-SNAPSHOT</version>
+		<version>1.0.114</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>data-migrator-core</artifactId>

--- a/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/BatchDataMigrator.java
+++ b/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/BatchDataMigrator.java
@@ -1,0 +1,385 @@
+package com.izettle.data.migrator.core;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Specialization of {@link DataMigrator} for batch migrations.
+ *
+ * Given a DAO that implements {@link BatchSupportedDao}, implementations of this class are able to execute the
+ * statement given by {@code ToExecute}, which should batch migrate records of type {@code FromData}, in multiple
+ * Threads.
+ *
+ * The process may be cancelled at any time by calling the {@link BatchDataMigrator#cancel()} method. This will
+ * forcibly kill all Threads and completely abort the migration process as soon as possible.
+ *
+ * Once the {@link BatchDataMigrator#cancel()} method is called, instances of this class must no longer be used.
+ *
+ * @param <FromData> type of objects to be migrated
+ * @param <ToExecute> action that migrates a batch of objects
+ */
+public abstract class BatchDataMigrator<FromData, ToExecute>
+    implements DataMigrator<List<FromData>, ToExecute> {
+
+    private static final int MAX_UNRECOVERABLE_ERRORS = 10;
+
+    protected final Logger log;
+
+    protected final String name;
+    protected final BatchSupportedDao<FromData> dao;
+    protected final int batchSize;
+    protected final int maxThreads;
+
+    private final LinkedBlockingDeque<List<FromData>> batchQueue;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private final ExecutorService executorService;
+    private final AtomicInteger unrecoverableErrorCount = new AtomicInteger();
+    private final AtomicReference<Runnable> onCancelCallback = new AtomicReference<>();
+    private final AtomicReference<MigrationThrottlingParameters> throttlingParameters
+        = new AtomicReference<>(MigrationThrottlingParameters.DEFAULT);
+
+    public static final AtomicInteger CONCURRENT_BATCHES_COUNT = new AtomicInteger();
+
+    /**
+     * Create a {@link BatchDataMigrator} instance.
+     *
+     * @param name of this data migrator (for debugging and metrics purposes)
+     * @param dao the DAO that provides the records to be migrated
+     * @param batchSize size of batches to process
+     * @param maxThreads number of Threads to use to process batches
+     */
+    public BatchDataMigrator(
+        String name,
+        BatchSupportedDao<FromData> dao,
+        int batchSize,
+        int maxThreads
+    ) {
+        this.name = name;
+        this.dao = dao;
+        this.batchSize = batchSize;
+        this.maxThreads = maxThreads;
+        this.batchQueue = new LinkedBlockingDeque<>(maxThreads);
+        this.log = LoggerFactory.getLogger(name);
+
+        AtomicInteger threadIndex = new AtomicInteger();
+
+        this.executorService = Executors.newFixedThreadPool(
+            maxThreads,
+            runnable -> new Thread(runnable, "batch-database-migrator-" + threadIndex.getAndIncrement())
+        );
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    public void setOnCancelCallback(Runnable callback) {
+        onCancelCallback.set(callback);
+    }
+
+    /**
+     * Migrate single item.
+     *
+     * @param from to migrate
+     */
+    protected abstract void migrateSingleItem(FromData from) throws InterruptedException;
+
+    @Override
+    public void executeAsync(ToExecute toExecute) {
+        throw new UnsupportedOperationException("Cannot run batch statement asynchronously");
+    }
+
+    @Override
+    public void migrate(List<FromData> from) throws InterruptedException {
+        Optional<ToExecute> statement = transform(from);
+        if (statement.isPresent()) {
+            // the default migrate( ) implementation runs async, override for batches to run synchronously
+            execute(statement.get());
+        }
+    }
+
+    private void verify(List<FromData> batch) {
+        boolean isBatchMigrated = isMigrated(batch);
+
+        if (!isBatchMigrated) {
+            log.error("Detected a batch with rows that did not get migrated correctly, aborting migration");
+            cancel();
+        }
+    }
+
+    /**
+     * Run a full database migration.
+     * <p/>
+     * This method may start several Threads to perform the migration, but once it returns,
+     * it is guaranteed that all Threads will have completed.
+     * <p/>
+     * Calling this method more than once has no effect.
+     * <p/>
+     * To stop the migration process, call the {@link BatchDataMigrator#cancel()} method.
+     */
+    public final void runFullMigration() {
+        if (!cancelled.get() && running.compareAndSet(false, true)) {
+            log.info("Starting full database migration using {} threads", maxThreads);
+
+            // start all workers at once, so they can start consuming the batch queue immediately
+            for (int i = 0; i < maxThreads; i++) {
+                executorService.submit(new Worker());
+            }
+
+            final AtomicInteger totalBatchesProcessed = new AtomicInteger(0);
+
+            try {
+                dao.forEachBatch(batchSize, batch -> {
+                    boolean batchWasAccepted = false;
+                    CONCURRENT_BATCHES_COUNT.incrementAndGet();
+                    try {
+                        while (!batchWasAccepted) {
+                            try {
+                                // it's necessary to only try to insert the batch into the queue if the migration has
+                                // not been cancelled, otherwise, if the queue is full, this could block.
+                                if (cancelled.get()) {
+                                    return false;
+                                }
+
+                                // waiting if necessary for the queue to make space available...
+                                // this applies "back-pressure" in our consumer, so we don't load the whole database
+                                // into memory in case the writers are too much slower than this reader
+                                batchWasAccepted = batchQueue.offer(batch, 1, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                // this can only happen if our Thread was interrupted, so stop the migration in such
+                                // case
+                                log.warn("Main database migrator Thread has been interrupted! Stopping migration.");
+                                cancel();
+                                return false;
+                            }
+                        }
+
+                        final int totalBatches = totalBatchesProcessed.incrementAndGet();
+                        final MigrationThrottlingParameters throttlingParams = throttlingParameters.get();
+
+                        // throttle if needed
+                        if (throttlingParams.getSleepInMillis() > 0L &&
+                            (totalBatches % throttlingParams.getBatchesBetweenSleeps()) == 0) {
+                            try {
+                                log.info("Throttling current batch {}. Sleeping for {} ms", totalBatches,
+                                    throttlingParams.getSleepInMillis()
+                                );
+                                Thread.sleep(throttlingParams.getSleepInMillis());
+                            } catch (InterruptedException e) {
+                                log.warn("Interrupted while throttling data migration batches");
+                                cancel();
+                            }
+                        }
+                    } finally {
+                        CONCURRENT_BATCHES_COUNT.decrementAndGet();
+                    }
+                    return !cancelled.get(); // i.e. continue processing more batches unless cancelled
+                });
+            } catch (Exception e) {
+                log.error("Problem running database migration", e);
+                cancel();
+            }
+
+            // by now, all batches have been processed, stop the executor and wait for all workers to exit
+            executorService.shutdownNow();
+
+            try {
+                executorService.awaitTermination(20, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while waiting for all workers to stop", e);
+            } finally {
+                running.set(false);
+            }
+
+            if (cancelled.get()) {
+                log.info("DATABASE MIGRATION ABORTED!");
+            } else {
+                log.info("DATABASE MIGRATION COMPLETE!");
+            }
+
+        } else if (cancelled.get()) {
+            throw new IllegalStateException("Cannot re-start migration after it was cancelled");
+        }
+    }
+
+    /**
+     * When a batch fails to be migrated, the likely reason is that one or more of the records have already been
+     * migrated via an external process. To recover from such cases and make sure we don't miss any record, we
+     * attempt to migrate one-by-one, first checking if the item has NOT been migrated.
+     * <p/>
+     * If an item has already been migrated, no re-attempt is made to migrate the record.
+     * <p/>
+     * If an error happens even after it has been established that a record has not been migrated, then it's logged
+     * an an ERROR so that it's possible to later manually find the record and try to fix it.
+     *
+     * @param batch to migrate one-by-one
+     * @return true to continue, false if the migration has been cancelled
+     */
+    private boolean attemptToMigrateOneByOne(List<FromData> batch) {
+        log.info("Attempting to migrate batch rows one-by-one due to problem inserting full batch at once");
+        for (FromData item : batch) {
+            if (cancelled.get()) {
+                return false;
+            }
+            boolean alreadyMigrated;
+            try {
+                alreadyMigrated = dao.exists(item);
+            } catch (Exception e) {
+                log.error("Unable to verify whether item had already been migrated: {}\nReason: {}", item, e);
+                int totalErrors = unrecoverableErrorCount.incrementAndGet();
+
+                if (totalErrors > MAX_UNRECOVERABLE_ERRORS) {
+                    log.error("Too many unrecoverable errors, aborting database migration!");
+                    cancel();
+                    return false;
+                }
+                continue;
+            }
+            if (!alreadyMigrated) {
+                try {
+                    migrateSingleItem(item);
+                } catch (InterruptedException e) {
+                    log.warn("Interrupted while trying to migrate single item");
+                    return false;
+                } catch (Exception e) {
+                    log.error("Unable to migrate individual item after all attempts failed: {}", item, e);
+                    unrecoverableErrorCount.incrementAndGet();
+                }
+            } else {
+                log.debug("Not migrating item as it already exists: {}", item);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Cancel the database migration.
+     * <p/>
+     * Notice that after calling this method, this migrator cannot be re-started.
+     */
+    public final void cancel() {
+        if (!cancelled.getAndSet(true)) {
+            log.warn("Cancelling database migration");
+            cancelled.set(true);
+            dao.stopMigration();
+            Runnable callback = onCancelCallback.getAndSet(null);
+            if (callback != null) {
+                callback.run();
+            }
+        }
+    }
+
+    public void setThrottlingParameters(final MigrationThrottlingParameters parameters) {
+        this.throttlingParameters.set(parameters);
+    }
+
+    enum QueuingOption {
+        EXIT_WHEN_QUEUE_IS_EMPTY,
+        CONTINUE_EVEN_WITH_EMPTY_QUEUE
+    }
+
+    private class Worker implements Runnable {
+
+        @Override
+        public void run() {
+            log.info("Migrator Thread '{}' starting!", Thread.currentThread().getName());
+
+            try {
+                boolean isCancelled = consumeQueue(QueuingOption.CONTINUE_EVEN_WITH_EMPTY_QUEUE);
+                if (isCancelled) {
+                    log.info("Worker Thread '{}' cancelled", Thread.currentThread().getName());
+                    return; // don't log success at the end!
+                }
+            } catch (InterruptedException e) {
+                // this is expected at the end of the migration, start loop again, but exit if queue is empty
+                try {
+                    log.info("Migrator Thread switching to queue draining mode: {}", Thread.currentThread().getName());
+                    consumeQueue(QueuingOption.EXIT_WHEN_QUEUE_IS_EMPTY);
+                } catch (InterruptedException e2) {
+                    log.warn("Unexpectedly interrupted worker while trying to drain the queue");
+                }
+            } catch (Throwable t) {
+                log.error("Migrator Thread '{}' cannot continue due to error", Thread.currentThread().getName(), t);
+                return;
+            }
+
+            log.info("Migrator Thread '{}' has finished its job!", Thread.currentThread().getName());
+        }
+
+        /**
+         * Consume the batch queue.
+         *
+         * @param queuingOption queuing option
+         * @return true if the worker has been cancelled, false otherwise
+         * @throws InterruptedException if the thread is interrupted
+         */
+        @SuppressWarnings("ConstantConditions") // "stopConsumingQueue" constant improves readability a little bit
+        private boolean consumeQueue(QueuingOption queuingOption) throws InterruptedException {
+            List<FromData> batch;
+
+            boolean stopConsumingQueue = true;
+
+            while (true) {
+                if (BatchDataMigrator.this.cancelled.get()) {
+                    log.info("Cancelled migrator Thread '{}'", Thread.currentThread().getName());
+                    return stopConsumingQueue;
+                }
+
+                switch (queuingOption) {
+                    case EXIT_WHEN_QUEUE_IS_EMPTY:
+                        batch = batchQueue.poll();
+                        if (batch == null) { // this means the queue has no elements!
+                            return !stopConsumingQueue;
+                        }
+                        break;
+                    case CONTINUE_EVEN_WITH_EMPTY_QUEUE:
+                        batch = batchQueue.poll(5, TimeUnit.SECONDS);
+                        break;
+                    default:
+                        throw new IllegalStateException("Missing enum case");
+                }
+
+                if (batch != null && !BatchDataMigrator.this.cancelled.get()) {
+                    try {
+                        migrate(batch);
+                    } catch (InterruptedException e) {
+                        log.info("Thread Interrupted while migrating a batch");
+                    } catch (Exception e) {
+                        // INFO level because this is expected when a row has already been migrated
+                        log.warn("There was an error migrating a batch", e);
+
+                        boolean toContinue = attemptToMigrateOneByOne(batch);
+                        if (!toContinue) {
+                            log.info("Cancelled migrator Thread '{}'", Thread.currentThread().getName());
+                            return stopConsumingQueue;
+                        }
+                    } finally {
+                        if (unrecoverableErrorCount.get() > MAX_UNRECOVERABLE_ERRORS) {
+                            log.error("Too many unrecoverable errors, aborting database migration!");
+                            cancel();
+                        } else if (!BatchDataMigrator.this.cancelled.get()) {
+                            verify(batch);
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/BatchSupportedDao.java
+++ b/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/BatchSupportedDao.java
@@ -1,0 +1,37 @@
+package com.izettle.data.migrator.core;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A DAO that can be used for batch operations.
+ *
+ * It must be Thread-safe because batch operations are typically run in multiple Threads.
+ * @param <DTO> POJO representing the objects managed by this DAO.
+ */
+public interface BatchSupportedDao<DTO> {
+
+    /**
+     * Process all records in the database in batches.
+     * @param batchSize size of each batch
+     * @param consumer action to perform on each batch. Return true to continue, false to stop.
+     */
+    void forEachBatch(int batchSize, Function<List<DTO>, Boolean> consumer);
+
+    /**
+     * Check whether the given DTO already exists in the database.
+     *
+     * @param dto DTO to check
+     * @return true if the DTO is in the database, false otherwise
+     */
+    boolean exists(DTO dto);
+
+    /**
+     * Stop performing one-by-one migrations if this DAO supports it.
+     *
+     * This method should not have any effect on the implementation of {@link #forEachBatch(int, Function)},
+     * it should only stop performing one-by-one migrations if it implements that functionality.
+     */
+    void stopMigration();
+
+}

--- a/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/DataMigrator.java
+++ b/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/DataMigrator.java
@@ -1,0 +1,63 @@
+package com.izettle.data.migrator.core;
+
+import java.util.Optional;
+
+/**
+ * This interface provides a way for DAOs to migrate Objects of type {@code FromData} to a new database or table
+ * specified by the {@code ToExecute} type.
+ *
+ * Users of this interface should only call the {@link DataMigrator#migrate(Object)} method.
+ *
+ * @param <FromData> type of objects to be migrated
+ * @param <ToExecute> action that migrates an object
+ */
+public interface DataMigrator<FromData, ToExecute> {
+
+    /**
+     * Transform object being migrated into a database statement that when executed, performs the actual migration.
+     *
+     * Users of this interface should call {@link DataMigrator#migrate(Object)} instead of this method.
+     *
+     * Returning an empty Optional causes the item to not be migrated.
+     *
+     * @param from object to be migrated
+     * @return statements that can be executed to perform the migration, or empty to ignore the entry
+     */
+    Optional<ToExecute> transform(FromData from);
+
+    /**
+     * Execute the migration statement asynchronously.
+     *
+     * Users of this interface should call {@link DataMigrator#migrate(Object)} instead of this method.
+     *
+     * @param toExecute database statement that performs the migration of a single object
+     */
+    void executeAsync(ToExecute toExecute);
+
+    /**
+     * Execute the migration statement.
+     *
+     * Users of this interface should call {@link DataMigrator#migrate(Object)} instead of this method.
+     *
+     * @param toExecute database statement that performs the migration of a single object
+     * @throws InterruptedException if the current Thread is interrupted while executing the statement
+     */
+    void execute(ToExecute toExecute) throws InterruptedException;
+
+    /**
+     * @param from record to check
+     * @return true if the given record has been migrated successfully, false otherwise
+     */
+    boolean isMigrated(FromData from);
+
+    /**
+     * Migrate the given object.
+     *
+     * @param from object to be migrated
+     * @throws InterruptedException if the current Thread is interrupted while executing the migration
+     */
+    default void migrate(FromData from) throws InterruptedException {
+        transform(from).ifPresent(this::executeAsync);
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/MigrationThrottlingParameters.java
+++ b/izettle-data-migrator/data-migrator-core/src/main/java/com/izettle/data/migrator/core/MigrationThrottlingParameters.java
@@ -1,0 +1,30 @@
+package com.izettle.data.migrator.core;
+
+public final class MigrationThrottlingParameters {
+
+    private static final int NEVER_SLEEP = Integer.MAX_VALUE;
+
+    public static final MigrationThrottlingParameters DEFAULT =
+        new MigrationThrottlingParameters(NEVER_SLEEP, -1L);
+
+    private final int batchesBetweenSleeps;
+    private final long sleepInMillis;
+
+    public MigrationThrottlingParameters(final int batchesBetweenSleeps, final long sleepInMillis) {
+
+        // must be non-zero, positive (as this will be used in division via the module operator)!
+        this.batchesBetweenSleeps = batchesBetweenSleeps < 1 ? NEVER_SLEEP : batchesBetweenSleeps;
+
+        // must be 0 or positive
+        this.sleepInMillis = Math.max(0L, sleepInMillis);
+    }
+
+    public int getBatchesBetweenSleeps() {
+        return batchesBetweenSleeps;
+    }
+
+    public long getSleepInMillis() {
+        return sleepInMillis;
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-core/src/test/java/com/izettle/data/migrator/core/AstyanaxSimulatedBatchDao.java
+++ b/izettle-data-migrator/data-migrator-core/src/test/java/com/izettle/data/migrator/core/AstyanaxSimulatedBatchDao.java
@@ -1,0 +1,125 @@
+package com.izettle.data.migrator.core;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+/**
+ * This is a test class that tries to simulate as closely as possible the beahaviour of a
+ * DAO that is based on the Cassandra Astyanax driver.
+ * <p/>
+ * For example, the default implementation of {@link AstyanaxSimulatedBatchDao#forEachBatch(int, Function)}
+ * simulates an Astyanax DAO connecting to 3 Cassandra nodes, therefore using 3 Threads, one for each node,
+ * to run the for-each callaback to process batches.
+ *
+ * @param <DTO>
+ */
+public class AstyanaxSimulatedBatchDao<DTO> implements BatchSupportedDao<DTO> {
+
+    private final List<DTO> oldRecords;
+    private final Set<DTO> dtosToReportAlreadyMigrated;
+    private final List<List<DTO>> migratedRecords = Collections.synchronizedList(new ArrayList<>());
+    private final int concurrencyLevel;
+
+    public AstyanaxSimulatedBatchDao(
+        List<DTO> oldRecords,
+        Set<DTO> dtosToReportAlreadyMigrated,
+        int concurrencyLevel
+    ) {
+        if (concurrencyLevel < 1) {
+            throw new IllegalArgumentException("Concurrency level must be at least 1");
+        }
+
+        this.oldRecords = Collections.synchronizedList(new ArrayList<>(oldRecords));
+        this.dtosToReportAlreadyMigrated = dtosToReportAlreadyMigrated;
+        this.concurrencyLevel = concurrencyLevel;
+    }
+
+    public AstyanaxSimulatedBatchDao(List<DTO> oldRecords) {
+        this(oldRecords, emptySet(), 3);
+    }
+
+    @Override
+    public boolean exists(DTO s) {
+        return dtosToReportAlreadyMigrated.contains(s);
+    }
+
+    @Override
+    public void forEachBatch(
+        int batchSize, Function<List<DTO>, Boolean> consumer
+    ) {
+        // simulate a real DAO's multi-Threaded for-each implementation
+        Iterator<DTO> iterator = oldRecords.iterator();
+
+        List<Thread> threads = IntStream.range(0, concurrencyLevel)
+            .mapToObj(i -> new Thread(createForEachPublisher(iterator, batchSize, consumer)))
+            .collect(toList());
+
+        threads.forEach(Thread::start);
+
+        try {
+            for (Thread t : threads) {
+                t.join();
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Runnable createForEachPublisher(
+        Iterator<DTO> iterator,
+        int batchSize,
+        Function<List<DTO>, Boolean> consumer
+    ) {
+        return () -> {
+            boolean done = false;
+
+            while (!done) {
+                List<DTO> batch = new ArrayList<>(batchSize);
+
+                synchronized (iterator) {
+                    for (int i = 0; i < batchSize; i++) {
+                        if (iterator.hasNext()) {
+                            batch.add(iterator.next());
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                if (batch.isEmpty()) {
+                    done = true;
+                } else {
+                    boolean toContinue = consumer.apply(batch);
+
+                    done = !iterator.hasNext() || !toContinue;
+                }
+            }
+        };
+    }
+
+    public void accept(List<DTO> records) {
+        migratedRecords.add(records);
+    }
+
+    public List<DTO> getOldRecords() {
+        return oldRecords;
+    }
+
+    public List<List<DTO>> getMigratedRecords() {
+        return new ArrayList<>(migratedRecords);
+    }
+
+    @Override
+    public void stopMigration() {
+        // nothing to do
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-core/src/test/java/com/izettle/data/migrator/core/BatchDataMigratorTest.java
+++ b/izettle-data-migrator/data-migrator-core/src/test/java/com/izettle/data/migrator/core/BatchDataMigratorTest.java
@@ -1,0 +1,219 @@
+package com.izettle.data.migrator.core;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+public class BatchDataMigratorTest {
+
+    @Test
+    public void migratorRunsToCompletion() {
+        AstyanaxSimulatedBatchDao<String> dao = new AstyanaxSimulatedBatchDao<>(asList(
+            "a", "b", "c", "d", "e", "f", "g"
+        ));
+        TestBatchMigrator migrator = new TestBatchMigrator(dao, 2, 3);
+
+        // run a full migration: this should span 3 Threads, processing batches of size 2
+        migrator.runFullMigration();
+
+        // verify that the batches were processed as expected, in any order
+        assertThat(new HashSet<>(dao.getMigratedRecords())).isEqualTo(new HashSet<>(asList(
+            asList("a", "b"), asList("c", "d"), asList("e", "f"), singletonList("g"))
+        ));
+    }
+
+    @Test
+    public void migratorCanMigrateLargeAmountsOfRecordsInManyThreads() {
+        final int totalRecords = 100_000;
+        final int batchSize = 100;
+
+        List<String> records = IntStream.range(0, totalRecords)
+            .mapToObj(Integer::toString)
+            .collect(toList());
+
+        AstyanaxSimulatedBatchDao<String> dao = new AstyanaxSimulatedBatchDao<>(records);
+
+        // batches of 100 records, processed in 20 Threads
+        TestBatchMigrator migrator = new TestBatchMigrator(dao, batchSize, 20);
+
+        migrator.runFullMigration();
+
+        List<List<String>> expectedBatches = new ArrayList<>(totalRecords / batchSize);
+
+        for (int i = 0; i < totalRecords; i += batchSize) {
+            expectedBatches.add(IntStream.range(i, i + batchSize)
+                .mapToObj(Integer::toString)
+                .collect(toList()));
+        }
+
+        // verify that the batches were processed as expected, in any order
+        assertThat(new HashSet<>(dao.getMigratedRecords()))
+            .isEqualTo(new HashSet<>(expectedBatches));
+    }
+
+    @Test
+    public void migratorRunsToCompletionEvenIfErrorOccursOnExecutingMigrationStatement() {
+        // this DAO will report the first batch items as having already been migrated
+        // so that when the first batch fails to be migrated, it will not be attempted item-by-item
+        AstyanaxSimulatedBatchDao<String> dao = new AstyanaxSimulatedBatchDao<>(asList(
+            "a", "b", "c", "d", "e", "f"
+        ), new HashSet<>(Arrays.asList("a", "b")), 1);
+
+        // this migrator will throw an error on the first execution
+        TestBatchMigrator migrator = new TestBatchMigrator(dao, 2, 1, 0, null, null);
+
+        // run a full migration: this should span 1 Thread, processing batches of size 2
+        migrator.runFullMigration();
+
+        // verify that the batches were processed as expected, in any order
+        // the first batch is always dropped
+        assertThat(new HashSet<>(dao.getMigratedRecords())).isEqualTo(new HashSet<>(asList(
+            asList("c", "d"), asList("e", "f"))
+        ));
+    }
+
+    @Test
+    public void migratorRunsToCompletionEvenIfErrorOccursOnExecutingMigrationStatementWithRecovery() {
+        // this DAO will never report an item as having already been migrated,
+        // therefore the item-by-item batch error recovery procedure will recover the failed batch
+        AstyanaxSimulatedBatchDao<String> dao = new AstyanaxSimulatedBatchDao<>(asList(
+            "a", "b", "c", "d", "e", "f"
+        ));
+
+        // this migrator will throw an error on the first execution
+        TestBatchMigrator migrator = new TestBatchMigrator(dao, 2, 2, 0, null, null);
+
+        // run a full migration: this should span 2 Threads, processing batches of size 2
+        migrator.runFullMigration();
+
+        // verify that the batches were processed as expected, in any order
+        // the first batch initially fails, but then the item-by-item migration recovers them
+        assertThat(new HashSet<>(dao.getMigratedRecords())).isEqualTo(new HashSet<>(asList(
+            singletonList("a"), singletonList("b"), asList("c", "d"), asList("e", "f"))
+        ));
+    }
+
+    @Test
+    public void migratorCanBeCancelled() throws InterruptedException {
+        AstyanaxSimulatedBatchDao<String> dao = new AstyanaxSimulatedBatchDao<>(asList(
+            "a", "b", "c", "d", "e", "f", "g"
+        ));
+
+        // migrator uses batch size of 2, 3 Threads and a delay per migrated row
+        TestBatchMigrator migrator = new TestBatchMigrator(dao, 2, 3, -1, Duration.ofMillis(4), null);
+
+        // run a full migration asynchronously
+        new Thread(migrator::runFullMigration).start();
+
+        // wait 5ms, which should allow 2 rows to be migrated because the 2 Threads can only do two
+        // rows every 4ms, then cancel the migration.
+        // Notice that because it might take a few ms for the call to cancel() to be reached, there's no
+        // guarantee that no more than 2 rows will be migrated... so we assume that cancel() can be called
+        // within 8ms of starting the migrator Thread, which lets us assert that at most 4 rows are migrated.
+        Thread.sleep(5L);
+        migrator.cancel();
+
+        // verify that at most 4 rows were processed (we can never guarantee that any Thread actually
+        // starts within 5ms, so we need to be tolerant and allow 0)
+        assertThat(dao.getMigratedRecords().size()).isBetween(0, 4);
+    }
+
+    @Test
+    public void migratorDetectsBadMigrationAndAborts() {
+        AstyanaxSimulatedBatchDao<String> dao = new AstyanaxSimulatedBatchDao<>(asList(
+            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"
+        ), emptySet(), 1);
+
+        // migrator uses batch size of 2, 1 Thread and reports the "c" item as not having been migrated correctly,
+        // which should cause the whole migration to be aborted.
+        // The migration should be forcibly cancelled, automatically, due to the problematic row,
+        // resulting in only the first batch not being migrated.
+        TestBatchMigrator migrator = new TestBatchMigrator(dao, 2, 1, -1, Duration.ofMillis(0L), "c");
+
+        // run a full migration: this should span 1 Thread, processing batches of size 2
+        // and should be cancelled automatically once the second batch is processed.
+        migrator.runFullMigration();
+
+        // verify that only the first 2 batches were migrated (the last of which fails and cancels the migration)
+        //noinspection unchecked
+        assertThat(new HashSet<>(dao.getMigratedRecords())).isEqualTo(
+            new HashSet<>(asList(asList("a", "b"), asList("c", "d"))));
+    }
+
+    private static class TestBatchMigrator
+        extends BatchDataMigrator<String, List<String>> {
+
+        private final AstyanaxSimulatedBatchDao<String> dao;
+        private final int executeIndexToThrowError;
+        private final Duration delayPerRow;
+        private final String itemToReportAsFailedToMigrate;
+        private final AtomicInteger executeIndex = new AtomicInteger();
+
+        TestBatchMigrator(
+            AstyanaxSimulatedBatchDao<String> dao,
+            int batchSize,
+            int maxThreads
+        ) {
+            this(dao, batchSize, maxThreads, -1, null, null);
+        }
+
+        TestBatchMigrator(
+            AstyanaxSimulatedBatchDao<String> dao,
+            int batchSize,
+            int maxThreads,
+            int executeIndexToThrowError,
+            Duration delayPerRow,
+            String itemToReportAsFailedToMigrate
+        ) {
+            super("test-migrator", dao, batchSize, maxThreads);
+            this.dao = dao;
+            this.executeIndexToThrowError = executeIndexToThrowError;
+            this.delayPerRow = delayPerRow;
+            this.itemToReportAsFailedToMigrate = itemToReportAsFailedToMigrate;
+        }
+
+        @Override
+        public Optional<List<String>> transform(List<String> from) {
+            return Optional.ofNullable(from);
+        }
+
+        @Override
+        public void execute(List<String> records) throws InterruptedException {
+            if (executeIndex.getAndIncrement() == executeIndexToThrowError) {
+                throw new RuntimeException("EXECUTE ERROR");
+            }
+            if (delayPerRow != null) {
+                Thread.sleep(delayPerRow.toMillis() * records.size());
+            }
+            dao.accept(records);
+        }
+
+        @Override
+        public boolean isMigrated(List<String> from) {
+            if (itemToReportAsFailedToMigrate != null) {
+                return !from.contains(itemToReportAsFailedToMigrate);
+            }
+
+            // report all items as having been migrated correctly
+            return true;
+        }
+
+        @Override
+        protected void migrateSingleItem(String from) throws InterruptedException {
+            dao.accept(singletonList(from));
+        }
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-dropwizard/pom.xml
+++ b/izettle-data-migrator/data-migrator-dropwizard/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
 		<groupId>com.izettle.toolbox</groupId>
 		<artifactId>izettle-data-migrator</artifactId>
-		<version>1.0.114-SNAPSHOT</version>
+		<version>1.0.114</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>data-migrator-dropwizard</artifactId>

--- a/izettle-data-migrator/data-migrator-dropwizard/pom.xml
+++ b/izettle-data-migrator/data-migrator-dropwizard/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>com.izettle.toolbox</groupId>
+		<artifactId>izettle-data-migrator</artifactId>
+		<version>1.0.114-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>data-migrator-dropwizard</artifactId>
+	<description>
+		Module extending data-migrator-core and Cassandra DataStax with Dropwizard tasks to run data migrations.
+	</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.izettle.toolbox</groupId>
+			<artifactId>data-migrator-cassandra-datastax</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.dropwizard</groupId>
+			<artifactId>dropwizard-servlets</artifactId>
+			<version>${dropwizard.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/izettle-data-migrator/data-migrator-dropwizard/pom.xml
+++ b/izettle-data-migrator/data-migrator-dropwizard/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.izettle.toolbox</groupId>
 		<artifactId>izettle-data-migrator</artifactId>
-		<version>1.0.114</version>
+		<version>1.0.115-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>data-migrator-dropwizard</artifactId>

--- a/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/BatchDataMigratorTask.java
+++ b/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/BatchDataMigratorTask.java
@@ -1,0 +1,172 @@
+package com.izettle.data.migrator.dropwizard;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.izettle.cassandra.CassandraSessionManaged;
+import com.izettle.data.migrator.cassandra.datastax.CassandraDataStaxMigratorParameters;
+import com.izettle.data.migrator.core.BatchDataMigrator;
+import com.izettle.data.migrator.core.MigrationThrottlingParameters;
+import io.dropwizard.servlets.tasks.Task;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dropwizard task that runs {@link BatchDataMigrator}s based on Cassandra's DataStax driver.
+ */
+public class BatchDataMigratorTask extends Task {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BatchDataMigratorTask.class);
+
+    private final Function<CassandraDataStaxMigratorParameters, List<BatchDataMigrator<?, ?>>>
+        databaseMigratorsSupplier;
+    private final AtomicReference<List<BatchDataMigrator<?, ?>>> currentMigrators = new AtomicReference<>();
+    private final CassandraSessionManaged cassandraSession;
+    private final AtomicReference<MigrationThrottlingParameters> migrationThrottlingParameters
+        = new AtomicReference<>(MigrationThrottlingParameters.DEFAULT);
+
+    /**
+     * Create a task to run Cassandra-DataStax-based data migrators.
+     * @param cassandraSession a Cassandra session to be used exclusively by the migrators. The session will be
+     *                         managed by this task, being started and closed when appropriate.
+     * @param databaseMigratorsSupplier supplier of migrators to be run.
+     */
+    public BatchDataMigratorTask(
+        CassandraSessionManaged cassandraSession,
+        Function<CassandraDataStaxMigratorParameters, List<BatchDataMigrator<?, ?>>> databaseMigratorsSupplier
+    ) {
+        super("batch-migrator");
+        this.cassandraSession = cassandraSession;
+        this.databaseMigratorsSupplier = databaseMigratorsSupplier;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter out) {
+        int batchSize, maxThreads, rowsToVerifyPerBatch;
+
+        try {
+            batchSize = Integer.parseInt(parameters.get("batchSize").iterator().next());
+            maxThreads = Integer.parseInt(parameters.get("maxThreads").iterator().next());
+            rowsToVerifyPerBatch = Integer.parseInt(parameters.get("rowsToVerifyPerBatch").iterator().next());
+        } catch (Exception e) {
+            out.println("ERROR (invalid argument): " + e);
+            return;
+        }
+
+        stopPreviousCassandraSession();
+
+        LOG.info("Starting a full Cassandra database data migration");
+
+        // start a session just to run the migrators... only close this session in case the migration gets
+        // cancelled (at the end of the batch migration, the migrators should continue active in order to
+        // perform the migration of any new items that the old DAOs create or update).
+        cassandraSession.start();
+
+        List<BatchDataMigrator<?, ?>> migrators = databaseMigratorsSupplier.apply(
+            new CassandraDataStaxMigratorParameters(
+                cassandraSession.getSession(),
+                batchSize,
+                maxThreads,
+                rowsToVerifyPerBatch
+            ));
+
+        synchronized (currentMigrators) {
+            if (currentMigrators.get() == null) {
+                currentMigrators.set(migrators);
+            } else {
+                out.println("Ignoring request to run BatchDataMigratorTask: task is already running.");
+                return;
+            }
+        }
+
+        // when one migrator is cancelled, all others should be also cancelled
+        migrators.forEach(m -> m.setOnCancelCallback(() -> {
+            cancel(null);
+            // call is idempotent, so we can call it multiple times without error
+            cassandraSession.stop();
+        }));
+
+        // let migrators know about the throttling policy
+        migrators.forEach(m -> m.setThrottlingParameters(migrationThrottlingParameters.get()));
+
+        out.println("Batch Data Migrator running with the following parameters:");
+        out.println("  * batchSize: " + batchSize);
+        out.println("  * maxThreads: " + maxThreads);
+        out.println("  * rowsToVerifyPerBatch: " + rowsToVerifyPerBatch);
+
+        // run migrators each in a different Thread
+        final ExecutorService executor = Executors.newFixedThreadPool(migrators.size());
+        final CompletionService<Void> completionService = new ExecutorCompletionService<>(executor);
+        migrators.forEach(m -> completionService.submit(m::runFullMigration, null));
+
+        // wait for all migrators to finish asynchronously
+        out.println("The following database migrators have been scheduled: " + migrators
+            .stream().map(BatchDataMigrator::getName).collect(joining(", ")));
+
+        new Thread(() -> {
+            int migratorCount = migrators.size();
+            while (migratorCount > 0) {
+                try {
+                    completionService.take();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } finally {
+                    migratorCount--;
+                }
+            }
+
+            LOG.info("All database migrators have finished running");
+
+            executor.shutdown();
+
+            // mark as not executed so that the task can be re-run if necessary
+            currentMigrators.set(null);
+        }, "database-migrator-scheduler").start();
+    }
+
+    private void stopPreviousCassandraSession() {
+        LOG.info("Stopping a previous data migration Cassandra Session");
+        cassandraSession.stop();
+    }
+
+    public List<BatchDataMigrator<?, ?>> getCurrentMigrators() {
+        List<BatchDataMigrator<?, ?>> activeMigrators = currentMigrators.get();
+        if (activeMigrators == null) {
+            return emptyList();
+        }
+        return activeMigrators;
+    }
+
+    public void setThrottling(MigrationThrottlingParameters parameters) {
+        requireNonNull(parameters, "Cannot accept null MigrationThrottlingParameters");
+        migrationThrottlingParameters.set(parameters);
+
+        for (BatchDataMigrator<?, ?> batchDataMigrator : getCurrentMigrators()) {
+            batchDataMigrator.setThrottlingParameters(parameters);
+        }
+    }
+
+    public void cancel(@Nullable PrintWriter out) {
+        Optional.ofNullable(currentMigrators.getAndSet(null))
+            .ifPresent(migrators -> {
+                if (out != null) {
+                    out.println("Cancelled the following migrators: "
+                        + migrators.stream().map(BatchDataMigrator::getName).collect(joining(", ")));
+                }
+                migrators.forEach(BatchDataMigrator::cancel);
+            });
+    }
+
+}

--- a/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/DataMigratorCancelTask.java
+++ b/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/DataMigratorCancelTask.java
@@ -1,0 +1,25 @@
+package com.izettle.data.migrator.dropwizard;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+import java.io.PrintWriter;
+
+/**
+ * Dropwizard Task to cancel a data migration.
+ */
+public class DataMigratorCancelTask extends Task {
+
+    private final BatchDataMigratorTask migratorTask;
+
+    public DataMigratorCancelTask(BatchDataMigratorTask migratorTask) {
+        super("cancel-migration");
+        this.migratorTask = migratorTask;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter out)
+        throws Exception {
+        out.println("Cancelling migrator task");
+        migratorTask.cancel(out);
+    }
+}

--- a/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/DataMigratorProgressTask.java
+++ b/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/DataMigratorProgressTask.java
@@ -1,0 +1,33 @@
+package com.izettle.data.migrator.dropwizard;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.izettle.data.migrator.core.BatchDataMigrator;
+import io.dropwizard.servlets.tasks.Task;
+import java.io.PrintWriter;
+import java.util.List;
+
+/**
+ * Dropwizard Task to return the progress of a running migration.
+ */
+public class DataMigratorProgressTask extends Task {
+
+    private final BatchDataMigratorTask migratorTask;
+
+    public DataMigratorProgressTask(BatchDataMigratorTask migratorTask) {
+        super("migration-progress");
+        this.migratorTask = migratorTask;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter out)
+        throws Exception {
+        out.println("Data Migrator status:");
+
+        List<BatchDataMigrator<?, ?>> migrators = migratorTask.getCurrentMigrators();
+        out.println("=========================================================");
+        out.println("Number of batches being currently processed: " + BatchDataMigrator.CONCURRENT_BATCHES_COUNT.get());
+        out.println("Number of migrators currently active: " + migrators.size());
+        migrators.forEach(m -> out.println(" * " + m.getName() + " is" + (m.isRunning() ? " " : " not ") + "running"));
+        out.println("=========================================================");
+    }
+}

--- a/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/DataMigratorThrottlingTask.java
+++ b/izettle-data-migrator/data-migrator-dropwizard/src/main/java/com/izettle/data/migrator/dropwizard/DataMigratorThrottlingTask.java
@@ -1,0 +1,38 @@
+package com.izettle.data.migrator.dropwizard;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.izettle.data.migrator.core.MigrationThrottlingParameters;
+import io.dropwizard.servlets.tasks.Task;
+import java.io.PrintWriter;
+
+/**
+ * Dropwizard task to set throttling on the main {@link BatchDataMigratorTask}.
+ */
+public class DataMigratorThrottlingTask extends Task {
+
+    private final BatchDataMigratorTask migratorTask;
+
+    public DataMigratorThrottlingTask(final BatchDataMigratorTask migratorTask) {
+        super("throttle-migration");
+        this.migratorTask = migratorTask;
+    }
+
+    @Override
+    public void execute(
+        final ImmutableMultimap<String, String> parameters,
+        final PrintWriter out
+    ) {
+        final int batchesBetweenSleeps, sleepInMillis;
+
+        try {
+            batchesBetweenSleeps = Integer.parseInt(parameters.get("batchesBetweenSleeps").iterator().next());
+            sleepInMillis = Integer.parseInt(parameters.get("sleepInMillis").iterator().next());
+        } catch (Exception e) {
+            out.println("ERROR (invalid argument): " + e);
+            return;
+        }
+
+        migratorTask.setThrottling(new MigrationThrottlingParameters(batchesBetweenSleeps, sleepInMillis));
+    }
+
+}

--- a/izettle-data-migrator/pom.xml
+++ b/izettle-data-migrator/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114-SNAPSHOT</version>
+		<version>1.0.114</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>izettle-data-migrator</artifactId>

--- a/izettle-data-migrator/pom.xml
+++ b/izettle-data-migrator/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>izettle-toolbox</artifactId>
+		<groupId>com.izettle.toolbox</groupId>
+		<version>1.0.114-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>izettle-data-migrator</artifactId>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>data-migrator-core</module>
+		<module>data-migrator-cassandra-datastax</module>
+		<module>data-migrator-dropwizard</module>
+	</modules>
+
+</project>

--- a/izettle-data-migrator/pom.xml
+++ b/izettle-data-migrator/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>izettle-toolbox</artifactId>
 		<groupId>com.izettle.toolbox</groupId>
-		<version>1.0.114</version>
+		<version>1.0.115-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>izettle-data-migrator</artifactId>

--- a/izettle-emv/pom.xml
+++ b/izettle-emv/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/izettle-emv/pom.xml
+++ b/izettle-emv/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/izettle-filters/pom.xml
+++ b/izettle-filters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
 
     <artifactId>izettle-filters</artifactId>

--- a/izettle-filters/pom.xml
+++ b/izettle-filters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
 
     <artifactId>izettle-filters</artifactId>

--- a/izettle-jackson/pom.xml
+++ b/izettle-jackson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
 
     <artifactId>izettle-jackson</artifactId>

--- a/izettle-jackson/pom.xml
+++ b/izettle-jackson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
 
     <artifactId>izettle-jackson</artifactId>

--- a/izettle-java-alb/pom.xml
+++ b/izettle-java-alb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/izettle-java-alb/pom.xml
+++ b/izettle-java-alb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/izettle-java/pom.xml
+++ b/izettle-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
 
     <artifactId>izettle-java</artifactId>

--- a/izettle-java/pom.xml
+++ b/izettle-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
 
     <artifactId>izettle-java</artifactId>

--- a/izettle-jdbi/pom.xml
+++ b/izettle-jdbi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/izettle-jdbi/pom.xml
+++ b/izettle-jdbi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/izettle-messaging/pom.xml
+++ b/izettle-messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114-SNAPSHOT</version>
+        <version>1.0.114</version>
     </parent>
 
     <artifactId>izettle-messaging</artifactId>

--- a/izettle-messaging/pom.xml
+++ b/izettle-messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>izettle-toolbox</artifactId>
         <groupId>com.izettle.toolbox</groupId>
-        <version>1.0.114</version>
+        <version>1.0.115-SNAPSHOT</version>
     </parent>
 
     <artifactId>izettle-messaging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <module>izettle-filters</module>
         <module>izettle-java-alb</module>
         <module>izettle-jackson</module>
+        <module>izettle-data-migrator</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
     <groupId>com.izettle.toolbox</groupId>
     <artifactId>izettle-toolbox</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.114-SNAPSHOT</version>
+    <version>1.0.114</version>
 
     <scm>
         <url>https://github.com/iZettle/izettle-toolbox</url>
         <connection>scm:git:git://github.com/iZettle/izettle-toolbox.git</connection>
         <developerConnection>scm:git:git:@github.com:iZettle/izettle-toolbox.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>izettle-toolbox-1.0.114</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
     <groupId>com.izettle.toolbox</groupId>
     <artifactId>izettle-toolbox</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.114</version>
+    <version>1.0.115-SNAPSHOT</version>
 
     <scm>
         <url>https://github.com/iZettle/izettle-toolbox</url>
         <connection>scm:git:git://github.com/iZettle/izettle-toolbox.git</connection>
         <developerConnection>scm:git:git:@github.com:iZettle/izettle-toolbox.git</developerConnection>
-        <tag>izettle-toolbox-1.0.114</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>


### PR DESCRIPTION
This framework for data migrations has already been reviewed and tested in the Authentication Server codebase.

This PR is simply moving the code into this project.

A main Maven module, `izettle-data-migrator`, was created to group the sub-projects:

* `data-migrator-core` the core code of the framework.
* `data-migrator-cassandra-datastax` extension of core for Cassandra Datastax-based migrators.
* `data-migrator-dropwizard` DW tasks to run migrators using Cassandra Datastax.

Usage of the framework is very simple and can be easily understood by reading the Javadocs.

But I can add more docs if needed.