### PR TITLE
Cart: Cleanup - Remove 'refund' as expression

### DIFF
--- a/izettle-cart/README.md
+++ b/izettle-cart/README.md
@@ -34,7 +34,7 @@ takes place on each line.
 ### Quantities
 Represented as `BigDecimal` to allow for arbitrarily precise values, e.g.
 0.000123 kg of saffron. Quantity is also the field indicating direction of the
-purchase: a refund cart would have negative quantities on most lines.
+purchase: a full return cart would have negative quantities on most lines.
 
 ### VAT Percentage
 In most countries, valid VAT percentages are expressed in whole numbers, but as
@@ -71,7 +71,7 @@ information on a per line level, and a total level. Each line is represented by
 a `ItemLine` or a `DiscountLine`. The object is queryable for properties such as
 grossValue, value, groupedVatAmounts etc. Also, the cart can be cloned into it's
 negative counterpart by calling `Cart.inverse()`, which is useful for example
-when creating a cart that is representing a full refund of the original.
+when creating a cart that is representing a full return of the original.
 
 ### `ItemLine`, `DiscountLine` and `ServiceChargeLine`
 These are the objects that will populate the cart's three different list
@@ -127,21 +127,21 @@ Cart {
 }
 ```
 
-## Full refunds
-When a full cart is refunded, there is no complex maths going on. The easiest
-way to create a new cart, representing the refund itself is by simply calling
+## Full returns
+When a full cart is returned, there is no complex maths going on. The easiest
+way to create a new cart, representing the return itself is by simply calling
 `Cart::inverse`: this will generate a cart with all quantities negated,
 effectively generating a cart with the opposite value. It's guaranteed to have
 the exact same (albeit negated) value as the original cart.
 
-## Partial alterations (refunds or additions)
-Partial refunds is a bit more complex than a full refund. Why so? Consider the
+## Partial returns
+Partial returns is a bit more complex than a full return. Why so? Consider the
 scenario when 10 units of item A with a price of 1 has been sold in the original
 cart. Also, the original cart had a 50% discount, effectively making the total
-value of the cart equal to 5. If each refunded unit of A would be calculated as
+value of the cart equal to 5. If each returned unit of A would be calculated as
 a separate cart, that would result in the customer getting 0 funds back each
 time. The only way to address this is to *always* take the original cart (and
-its possible previous refunds) into consideration, apply the sequence of
+its possible previous returns) into consideration, apply the sequence of
 reductions (alterations) to it and calculate the residual value. The amount of
 funds that's supposed to be paid back is the difference between the original
 value and the residual value. To aid handling this logic, there are two public
@@ -153,15 +153,13 @@ object `AlterationCart`, that can be queried for details such as value, vat,
 discount etc.
 
 Note one: Discounts are treated as distributed over all items, and will be to
-the disadvantage for the customer when calculating the value for the refund (an
+the disadvantage for the customer when calculating the value for the return (an
 alteration with negative quantities). This applies no matter if the discount is
 based on a percentage or on a fixed amount.
 
-Note two: An alteration can have negative quantities, and would then represent a
-refund event. The resulting `AlterationCart` will then also represent negative
-amounts (as something is removed from the original cart). If an alteration is
-positive, however, it will represent an addition to the original cart and
-consequently have positive values.
+Note two: An alteration always has negative quantities, and would then represent
+a return event. The resulting `AlterationCart` will then also represent negative
+amounts (as something is removed from the original cart).
 
 ### Example 1:
 Item A has a price of 10

--- a/izettle-cart/src/main/java/com/izettle/cart/AlterationCart.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/AlterationCart.java
@@ -8,7 +8,7 @@ import java.util.TreeMap;
 
 /**
  * A cart-like object representing the altered items. An alteration in itself doesn't behave exactly like a normal cart,
- * which is why this class is needed: to avoid rounding errors on repeated refunds issued on the same original cart,
+ * which is why this class is needed: to avoid rounding errors on repeated returns issued on the same original cart,
  * this class needs to compare the previous version of the cart with the current resulting one and answer all queries as
  * the difference between the two. This class doesn't have a public constructor: it should only be created by applying
  * an alteration operation on an existing cart object.

--- a/izettle-cart/src/main/java/com/izettle/cart/Cart.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/Cart.java
@@ -53,7 +53,7 @@ public class Cart<T extends Item<T, D>, D extends Discount<D>, K extends Discoun
 
     /**
      * Creates a new cart representing the results after altering quantities of some of the items. This would typically
-     * be used when doing a partial refund
+     * be used when doing a partial return
      * This instance is immutable and unaffected by this method call.
      * @param alteration The items to be altered in the cart. Needs to be a subset of the items in this cart
      * @return A newly created cart representing the state after the alteration. This cart is not intended to be exposed
@@ -140,7 +140,7 @@ public class Cart<T extends Item<T, D>, D extends Discount<D>, K extends Discoun
 
     /**
      * Creates a new cart representing the results after performing multiple quantity alterations of some of the items.
-     * This would typically be used when doing a partial refund
+     * This would typically be used when doing a partial return
      * This instance is immutable and unaffected by this method call.
      * @param alterations The items to be altered in the cart. Needs to be a subset of the items in this cart
      * @return A newly created cart representing the reduced cart
@@ -153,8 +153,8 @@ public class Cart<T extends Item<T, D>, D extends Discount<D>, K extends Discoun
     }
 
     /**
-     * Because it's impossible to calculate the value of a refund or addition without the context of it's original cart
-     * and possible previous alterations, this method does just that: calculates the value of a specific alteration.
+     * Because it's impossible to calculate the value of a return without the context of it's original cart and possible
+     * previous returns, this method does just that: calculates the value of a specific alteration.
      * As an example, let's consider a cart of 2 apples and 1 carrot with a % discount on the entire cart. First, there
      * is an alteration where one of the apples is returned. Then the carrot is returned, and now we ask: "How much
      * money is the return of the carrot worth?"
@@ -200,7 +200,7 @@ public class Cart<T extends Item<T, D>, D extends Discount<D>, K extends Discoun
 
     /**
      * Produces a new cart that is inversed, eg an identical cart where all quantities are negated. Useful for example
-     * for refunds
+     * for full returns.
      * This instance is immutable and unaffected by this method call.
      * @return the inversed cart
      */

--- a/izettle-cart/src/main/java/com/izettle/cart/Discount.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/Discount.java
@@ -30,7 +30,7 @@ public interface Discount<T> {
     /**
      * Utility method that subclasses need to implement. Inverse here, means the concept of negating the discount, which
      * would normally be done by cloning it's own fields, but negating the sign on the quantity. Used for situations
-     * such as refunds
+     * such as full returns.
      * @return the inversed Discount
      */
     T inverse();

--- a/izettle-cart/src/main/java/com/izettle/cart/Item.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/Item.java
@@ -30,7 +30,7 @@ public interface Item<T, K extends Discount<?>> {
     /**
      * Utility method that subclasses need to implement. Inverse here, means the concept of negating the line, which
      * would normally be done by cloning it's own fields, but negating the sign on the quantity. Used for situations
-     * such as refunds
+     * such as full returns.
      * @return the inversed Item
      */
     T inverse();

--- a/izettle-cart/src/main/java/com/izettle/cart/ServiceCharge.java
+++ b/izettle-cart/src/main/java/com/izettle/cart/ServiceCharge.java
@@ -32,7 +32,7 @@ public interface ServiceCharge<S> {
     /**
      * Utility method that subclasses need to implement. Inverse here, means the concept of negating the service charge, which
      * would normally be done by cloning it's own fields, but negating the sign on the amount. Used for situations
-     * such as refunds
+     * such as full returns.
      * @return the inversed ServiceCharge
      */
     S inverse();

--- a/izettle-cart/src/test/java/com/izettle/cart/AlterationTest.java
+++ b/izettle-cart/src/test/java/com/izettle/cart/AlterationTest.java
@@ -71,7 +71,7 @@ public class AlterationTest {
 
     @Test
     /**
-     * When the original line item has a rounded value, refunding small quantities at a time can be problematic: looking
+     * When the original line item has a rounded value, returning small quantities at a time can be problematic: looking
      * at one of those alterations separately would result in the same value each time. This in turn would make multiple
      * alterations add up to an amount higher or lower than the original cart. This test verifies that returning small
      * amounts will have different value each time until the entire value of the original cart is exhausted.
@@ -118,15 +118,15 @@ public class AlterationTest {
             itemWithNoDiscount
         );
         assertEquals(2100L, originalCart.getValue());
-        //refund an item part of a percentage disount: it shouldn't have it's full value
+        //return an item part of a percentage disount: it shouldn't have it's full value
         final Map<Object, BigDecimal> alteration1 = singletonMap(id1, BigDecimal.ONE.negate());
         final long alterationValue1 = originalCart.createAlterationCart(null, alteration1).getValue();
         assertEquals(-50L, alterationValue1);
-        //refund an item part of a fixed amount disount: it shouldn't have it's full value
+        //return an item part of a fixed amount disount: it shouldn't have it's full value
         final Map<Object, BigDecimal> alteration2 = singletonMap(id2, BigDecimal.ONE.negate());
         final long alterationValue2 = originalCart.createAlterationCart(null, alteration2).getValue();
         assertEquals(-175L, alterationValue2);
-        //refund an item without any discount at all should yield the same value as originally
+        //return an item without any discount at all should yield the same value as originally
         final Map<Object, BigDecimal> alteration3 = singletonMap(id3, BigDecimal.ONE.negate());
         final long alterationValue3 = originalCart.createAlterationCart(null, alteration3).getValue();
         assertEquals(-300L, alterationValue3);
@@ -220,9 +220,9 @@ public class AlterationTest {
             new TestItem(id1, "Main thing", 1L, 30f, BigDecimal.valueOf(1L), new TestDiscount(10L, null, BigDecimal.ONE))
         );
         final long originalValue = cart.getValue();
-        final Map<Object, BigDecimal> currentRefund = Maps.newHashMap(id1, BigDecimal.ONE.negate());
+        final Map<Object, BigDecimal> currentReturn = Maps.newHashMap(id1, BigDecimal.ONE.negate());
         final AlterationCart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> alterationCart = cart
-            .createAlterationCart(null, currentRefund);
+            .createAlterationCart(null, currentReturn);
         final long alterationValue = alterationCart.getValue();
         assertEquals(originalValue, -1 * alterationValue);
     }
@@ -238,9 +238,9 @@ public class AlterationTest {
             new TestItem(id, "Main thing", 1L, 30f, BigDecimal.valueOf(1L), new TestDiscount(null, 50d, BigDecimal.ONE))
         );
         final long originalValue = cart.getValue();
-        final Map<Object, BigDecimal> currentRefund = Maps.newHashMap(id, BigDecimal.ONE.negate());
+        final Map<Object, BigDecimal> currentReturn = Maps.newHashMap(id, BigDecimal.ONE.negate());
         final AlterationCart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> alterationCart2 = cart
-            .createAlterationCart(null, currentRefund);
+            .createAlterationCart(null, currentReturn);
         final long alterationValue2 = alterationCart2.getValue();
         assertEquals(originalValue, -1 * alterationValue2);
     }
@@ -261,11 +261,11 @@ public class AlterationTest {
             );
         final long originalValue = cart.getValue();
         final Map<Object, BigDecimal> firstAlteration = Maps.newHashMap(id, BigDecimal.ONE.negate());
-        final Map<Object, BigDecimal> currentRefund = Maps.newHashMap(id, BigDecimal.ONE.negate());
+        final Map<Object, BigDecimal> currentReturn = Maps.newHashMap(id, BigDecimal.ONE.negate());
         final AlterationCart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> firstAlterationCart = cart
             .createAlterationCart(null, firstAlteration);
         final AlterationCart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> secondAlterationCart = cart
-            .createAlterationCart(Arrays.asList(firstAlteration), currentRefund);
+            .createAlterationCart(Arrays.asList(firstAlteration), currentReturn);
         final long firstAlterationValue = firstAlterationCart.getValue();
         final long secondalterationValue = secondAlterationCart.getValue();
         assertEquals(originalValue, -1 * (firstAlterationValue + secondalterationValue));
@@ -287,11 +287,11 @@ public class AlterationTest {
             );
         final long originalValue = cart.getValue();
         final Map<Object, BigDecimal> firstAlteration = Maps.newHashMap(id, BigDecimal.ONE.negate());
-        final Map<Object, BigDecimal> currentRefund = Maps.newHashMap(id, BigDecimal.ONE.negate());
+        final Map<Object, BigDecimal> currentReturn = Maps.newHashMap(id, BigDecimal.ONE.negate());
         final AlterationCart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> firstAlterationCart = cart
             .createAlterationCart(null, firstAlteration);
         final AlterationCart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> secondAlterationCart = cart
-            .createAlterationCart(Arrays.asList(firstAlteration), currentRefund);
+            .createAlterationCart(Arrays.asList(firstAlteration), currentReturn);
         final long firstAlterationValue = firstAlterationCart.getValue();
         final long secondalterationValue = secondAlterationCart.getValue();
         assertEquals(originalValue, -1 * (firstAlterationValue + secondalterationValue));


### PR DESCRIPTION
As it's misleading: re*fund* is about the financial consequence of a
product return, not about the shopping cart activity.

Using the de-facto standard naming of 'return' instead.

ping @joaxand : it's at least a start :)