### PR TITLE
Introduces izettle-kotlin library

### DIFF
--- a/izettle-cart/src/test/java/com/izettle/cart/AlterationTest.java
+++ b/izettle-cart/src/test/java/com/izettle/cart/AlterationTest.java
@@ -75,7 +75,7 @@ public class AlterationTest {
      * at one of those alterations separately would result in the same value each time. This in turn would make multiple
      * alterations add up to an amount higher or lower than the original cart. This test verifies that returning small
      * amounts will have different value each time until the entire value of the original cart is exhausted.
-    */
+     */
     public void itShouldHandleMultipleAlterationsGracefully() {
         final Object id1 = UUID.randomUUID();
         final Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> originalCart = createCart(
@@ -217,7 +217,14 @@ public class AlterationTest {
     public void itShouldHandleFullDrainageForFixedLineItemDiscounts() {
         final Object id1 = UUID.randomUUID();
         final Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> cart = createCart(
-            new TestItem(id1, "Main thing", 1L, 30f, BigDecimal.valueOf(1L), new TestDiscount(10L, null, BigDecimal.ONE))
+            new TestItem(
+                id1,
+                "Main thing",
+                1L,
+                30f,
+                BigDecimal.valueOf(1L),
+                new TestDiscount(10L, null, BigDecimal.ONE)
+            )
         );
         final long originalValue = cart.getValue();
         final Map<Object, BigDecimal> currentReturn = Maps.newHashMap(id1, BigDecimal.ONE.negate());
@@ -255,10 +262,10 @@ public class AlterationTest {
         final TestDiscount discount = new TestDiscount(10L, null, BigDecimal.ONE);
         final Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> cart
             = new Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge>(
-                Arrays.asList(createItem(id, 10L, 30f, BigDecimal.valueOf(2L))),
-                Arrays.asList(discount),
-                null
-            );
+            Arrays.asList(createItem(id, 10L, 30f, BigDecimal.valueOf(2L))),
+            Arrays.asList(discount),
+            null
+        );
         final long originalValue = cart.getValue();
         final Map<Object, BigDecimal> firstAlteration = Maps.newHashMap(id, BigDecimal.ONE.negate());
         final Map<Object, BigDecimal> currentReturn = Maps.newHashMap(id, BigDecimal.ONE.negate());
@@ -281,10 +288,10 @@ public class AlterationTest {
         final TestDiscount discount = new TestDiscount(null, 20d, BigDecimal.ONE);
         final Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> cart
             = new Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge>(
-                Arrays.asList(createItem(id, 10L, 30f, BigDecimal.valueOf(2L))),
-                Arrays.asList(discount),
-                null
-            );
+            Arrays.asList(createItem(id, 10L, 30f, BigDecimal.valueOf(2L))),
+            Arrays.asList(discount),
+            null
+        );
         final long originalValue = cart.getValue();
         final Map<Object, BigDecimal> firstAlteration = Maps.newHashMap(id, BigDecimal.ONE.negate());
         final Map<Object, BigDecimal> currentReturn = Maps.newHashMap(id, BigDecimal.ONE.negate());
@@ -303,13 +310,20 @@ public class AlterationTest {
         final Object id2 = UUID.randomUUID();
         final Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> cart
             = new Cart<TestItem, TestDiscount, TestDiscount, TestServiceCharge>(
-                Arrays.asList(
-                    new TestItem(id1, "banan", 1000L, 30f, BigDecimal.valueOf(2L), new TestDiscount(200L, null, BigDecimal.ONE)),
-                    new TestItem(id2, "äpple", 1000L, 30f, BigDecimal.valueOf(1L), null)
+            Arrays.asList(
+                new TestItem(
+                    id1,
+                    "banan",
+                    1000L,
+                    30f,
+                    BigDecimal.valueOf(2L),
+                    new TestDiscount(200L, null, BigDecimal.ONE)
                 ),
-                Arrays.asList(new TestDiscount(600L, null, BigDecimal.ONE)),
-                null
-            );
+                new TestItem(id2, "äpple", 1000L, 30f, BigDecimal.valueOf(1L), null)
+            ),
+            Arrays.asList(new TestDiscount(600L, null, BigDecimal.ONE)),
+            null
+        );
         final Map<Object, BigDecimal> currentAlteration = Maps.newHashMap(id1, BigDecimal.ONE.negate());
         final AlterationCart<TestItem, TestDiscount, TestDiscount, TestServiceCharge> firstAlterationCart = cart
             .createAlterationCart(null, currentAlteration);
@@ -370,7 +384,8 @@ public class AlterationTest {
         assertEquals("Expected the first returned item to have value -1L", -1L, itemLines1.get(0).getActualValue());
 
         //when
-        final AlterationCart alterationCart2 = originalCart.createAlterationCart(Arrays.asList(alteration1), alteration2);
+        final AlterationCart alterationCart2 =
+            originalCart.createAlterationCart(Arrays.asList(alteration1), alteration2);
         //then
         final List<ItemLine> itemLines2 = alterationCart2.getItemLines();
         assertEquals("Expected the second returned item to have value -0L", 0L, itemLines2.get(0).getActualValue());
@@ -391,7 +406,7 @@ public class AlterationTest {
         );
         final List<TestDiscount> discounts = Arrays.asList(new TestDiscount(null, 50d, BigDecimal.ONE));
         final Cart originalCart = new Cart(items, discounts, null);
-        final Map alteration = new HashMap<Object, BigDecimal>(){
+        final Map alteration = new HashMap<Object, BigDecimal>() {
             {
                 put(id1, BigDecimal.valueOf(-2L));
                 put(id2, BigDecimal.valueOf(-3L));

--- a/izettle-kotlin/pom.xml
+++ b/izettle-kotlin/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.izettle.toolbox</groupId>
+        <artifactId>izettle-toolbox</artifactId>
+        <version>1.0.122-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>izettle-kotlin</artifactId>
+    <version>1.0.122-SNAPSHOT</version>
+
+    <properties>
+        <kotlin.version>1.2.71</kotlin.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.izettle.toolbox</groupId>
+            <artifactId>izettle-java</artifactId>
+            <version>1.0.122-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <inherited>true</inherited>
+                <configuration>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <optimize>true</optimize>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/izettle-kotlin/src/main/kotlin/com/izettle/kotlin/Optionals.kt
+++ b/izettle-kotlin/src/main/kotlin/com/izettle/kotlin/Optionals.kt
@@ -1,0 +1,15 @@
+package com.izettle.kotlin
+
+import java.util.Optional
+
+/**
+ * Convert a Java Optional to a Kotlin nullable type to avoid handling Optionals in Kotlin.
+ *
+ * Usage:
+ * ```
+ * optional.asNullable()?.let { "has value $it" } ?: "empty"
+ * ```
+ *
+ * @see Optional
+ */
+fun <T : Any> Optional<T>.asNullable(): T? = this.orElse(null)

--- a/izettle-kotlin/src/main/kotlin/com/izettle/kotlin/ValueChecks.kt
+++ b/izettle-kotlin/src/main/kotlin/com/izettle/kotlin/ValueChecks.kt
@@ -1,0 +1,143 @@
+package com.izettle.kotlin
+
+/**
+ * Takes any two nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * Usage:
+ * ```
+ * val field1: String? = null
+ * val field2: Int? = null
+ * whenNoneNull(field1, field2) { f1, f2 ->
+ *    f1.toUppercase() // non-nullable f1
+ *    f2.toString()    // non-nullable f2
+ * }
+ * ```
+ */
+inline fun <T1 : Any, T2 : Any, R : Any> whenNoneNull(p1: T1?, p2: T2?, block: (T1, T2) -> R?): R? {
+    return if (p1 != null && p2 != null) block(p1, p2) else null
+}
+
+/**
+ * Takes any 3 nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * @see whenNoneNull
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> whenNoneNull(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    block: (T1, T2, T3) -> R?
+): R? {
+    return if (p1 != null && p2 != null && p3 != null) block(p1, p2, p3) else null
+}
+
+/**
+ * Takes any 4 nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * @see whenNoneNull
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, R : Any> whenNoneNull(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    p4: T4?,
+    block: (T1, T2, T3, T4) -> R?
+): R? {
+    return if (p1 != null && p2 != null && p3 != null && p4 != null) block(p1, p2, p3, p4) else null
+}
+
+/**
+ * Takes any 5 nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * @see whenNoneNull
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, R : Any> whenNoneNull(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    p4: T4?,
+    p5: T5?,
+    block: (T1, T2, T3, T4, T5) -> R?
+): R? {
+    return if (p1 != null && p2 != null && p3 != null && p4 != null && p5 != null) block(p1, p2, p3, p4, p5) else null
+}
+
+/**
+ * Takes any 6 nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * @see whenNoneNull
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, R : Any> whenNoneNull(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    p4: T4?,
+    p5: T5?,
+    p6: T6?,
+    block: (T1, T2, T3, T4, T5, T6) -> R?
+): R? {
+    return if (p1 != null && p2 != null && p3 != null && p4 != null && p5 != null && p6 != null)
+        block(p1, p2, p3, p4, p5, p6) else null
+}
+
+/**
+ * Takes any 7 nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * @see whenNoneNull
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, R : Any> whenNoneNull(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    p4: T4?,
+    p5: T5?,
+    p6: T6?,
+    p7: T7?,
+    block: (T1, T2, T3, T4, T5, T6, T7) -> R?
+): R? {
+    return if (p1 != null && p2 != null && p3 != null && p4 != null && p5 != null && p6 != null && p7 != null)
+        block(p1, p2, p3, p4, p5, p6, p7) else null
+}
+
+/**
+ * Takes any 8 nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * @see whenNoneNull
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, R : Any> whenNoneNull(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    p4: T4?,
+    p5: T5?,
+    p6: T6?,
+    p7: T7?,
+    p8: T8?,
+    block: (T1, T2, T3, T4, T5, T6, T7, T8) -> R?
+): R? {
+    return if (p1 != null && p2 != null && p3 != null && p4 != null && p5 != null &&
+        p6 != null && p7 != null && p8 != null
+    ) block(p1, p2, p3, p4, p5, p6, p7, p8) else null
+}
+
+/**
+ * Takes any 9 nullable inputs and calls the specified block with non-null asserted versions of those inputs
+ *
+ * @see whenNoneNull
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any, T5 : Any, T6 : Any, T7 : Any, T8 : Any, T9 : Any, R : Any> whenNoneNull(
+    p1: T1?,
+    p2: T2?,
+    p3: T3?,
+    p4: T4?,
+    p5: T5?,
+    p6: T6?,
+    p7: T7?,
+    p8: T8?,
+    p9: T9?,
+    block: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R?
+): R? {
+    return if (p1 != null && p2 != null && p3 != null && p4 != null && p5 != null &&
+        p6 != null && p7 != null && p8 != null && p9 != null
+    ) block(p1, p2, p3, p4, p5, p6, p7, p8, p9) else null
+}

--- a/izettle-kotlin/src/test/kotlin/com/izettle/kotlin/OptionalsTest.kt
+++ b/izettle-kotlin/src/test/kotlin/com/izettle/kotlin/OptionalsTest.kt
@@ -1,0 +1,30 @@
+package com.izettle.kotlin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.Optional
+
+class OptionalsTest {
+
+    @Test
+    fun `should convert optional to nullable containing value`() {
+        val field: String? = "Test"
+
+        val optional = Optional.ofNullable(field)
+
+        val result = optional.asNullable()?.let { "has value $it" } ?: "empty"
+
+        assertThat(result).isEqualTo("has value Test")
+    }
+
+    @Test
+    fun `should convert optional to nullable with null value`() {
+        val field: String? = null
+
+        val optional = Optional.ofNullable(field)
+
+        val result = optional.asNullable()?.let { "has value $it" } ?: "empty"
+
+        assertThat(result).isEqualTo("empty")
+    }
+}

--- a/izettle-kotlin/src/test/kotlin/com/izettle/kotlin/ValueChecksTest.kt
+++ b/izettle-kotlin/src/test/kotlin/com/izettle/kotlin/ValueChecksTest.kt
@@ -1,0 +1,25 @@
+package com.izettle.kotlin
+
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ValueChecksTest {
+
+    @Test
+    fun `should return null when one argument is null`() {
+        val name: String? = null
+        val age: Int? = 40
+        whenNoneNull(name, age) { first, second ->
+            fail("Block was called with $first, $second")
+        }
+    }
+
+    @Test
+    fun `should call block when nothing is null`() {
+        val name: String? = "Test"
+        val age: Int? = 40
+        whenNoneNull(name, age) { first, second ->
+            println("Block was called with $first, $second")
+        } ?: fail("Block was not called")
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>izettle</artifactId>
-        <version>1.24</version>
+        <version>1.25</version>
     </parent>
 
     <groupId>com.izettle.toolbox</groupId>
@@ -21,6 +21,7 @@
 
     <modules>
         <module>izettle-java</module>
+        <module>izettle-kotlin</module>
         <module>izettle-messaging</module>
         <module>izettle-cryptography</module>
         <module>izettle-cassandra</module>


### PR DESCRIPTION
This PR introduces a new `izettle-kotlin` library into the toolbox. The motivation for this library is simply to make programming in Kotlin at iZettle easier and more enjoyable, and to reduce boilerplate and ceremony (a primary goal of Kotlin)

Initially, I have provided some functions that I think will make our Kotlin code more "Kotlin-like", by encouraging chains of calls and not `if` statements. We are already using the `whenNotNull` function in https://github.com/iZettle/online-payment and it would be much better to have it in a library like this one.

Here is a summary of the features this PR will provide:

```kotlin
// Introduces a whenNoneNull() global function that acts like a multi-variable ?.let()
// Supports between 2 and 9 arguments of different or same types

whenNoneNull(nullableName, nullableAge) { name, age ->
    println("Block was called with $name, $age, guaranteed to be non null")
} ?: throw Exception()


// Adds a mapper between Java Optional to a nullable Kotlin type, 
// to cut down on boilerplate in Kotlin code where we get Optionals 
// from legacy Java frameworks or code

val result = optional.asNullable()?.let { "has value $it" } ?: "empty"
```