### PR TITLE
Generic paging support for Datastax drivers

### DIFF
--- a/izettle-cassandra-datastax/pom.xml
+++ b/izettle-cassandra-datastax/pom.xml
@@ -29,6 +29,11 @@
 			<version>${cassandra-driver.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>com.datastax.cassandra</groupId>
+			<artifactId>cassandra-driver-mapping</artifactId>
+			<version>${cassandra-driver.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>io.dropwizard</groupId>
 			<artifactId>dropwizard-core</artifactId>
 			<version>${dropwizard.version}</version>

--- a/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingContext.java
+++ b/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingContext.java
@@ -1,0 +1,17 @@
+package com.izettle.cassandra.paging;
+
+import java.util.Optional;
+
+public interface PagingContext {
+
+    int getFetchSize();
+
+    default Optional<String> getPagingState() {
+        return Optional.empty();
+    }
+
+    static PagingContext create(int fetchSize) {
+        return () -> fetchSize;
+    }
+
+}

--- a/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingData.java
+++ b/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingData.java
@@ -1,0 +1,66 @@
+package com.izettle.cassandra.paging;
+
+import static java.util.Objects.requireNonNull;
+
+import com.datastax.driver.core.PagingState;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class PagingData<D> implements PagingContext, PagingInput<D> {
+
+    private static final String EMPTY_PAGE = null;
+
+    private D data;
+    private String pagingState;
+    private final int fetchSize;
+
+    public PagingData(PagingData<D> other) {
+        this.data = other.getData();
+        setPaging(other.pagingState);
+        this.fetchSize = other.getFetchSize();
+    }
+
+    public PagingData(PagingInput<D> input) {
+        this.data = input.getData();
+        this.fetchSize = input.getFetchSize();
+    }
+
+    public PagingData(final D input, int fetchSize) {
+        this.data = requireNonNull(input, "input must not be null");
+        this.fetchSize = fetchSize;
+    }
+
+    public PagingData(final D input, @Nullable final PagingState pagingState, int fetchSize) {
+        setPaging(pagingState);
+        this.data = input;
+        this.fetchSize = fetchSize;
+    }
+
+    public PagingData(final D input, @Nullable final String pagingState, int fetchSize) {
+        setPaging(pagingState);
+        this.data = input;
+        this.fetchSize = fetchSize;
+    }
+
+    public Optional<String> getPagingState() {
+        return Optional.ofNullable(pagingState);
+    }
+
+    public D getData() {
+        return data;
+    }
+
+    public PagingData<D> setPaging(@Nullable final PagingState page) {
+        this.pagingState = page != null ? page.toString() : EMPTY_PAGE;
+        return this;
+    }
+
+    public PagingData<D> setPaging(@Nullable final String page) {
+        this.pagingState = page;
+        return this;
+    }
+
+    public int getFetchSize() {
+        return fetchSize;
+    }
+}

--- a/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingFactory.java
+++ b/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingFactory.java
@@ -1,0 +1,216 @@
+package com.izettle.cassandra.paging;
+
+import static java.util.Objects.requireNonNull;
+
+import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.PagingIterable;
+import com.datastax.driver.core.PagingState;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.mapping.Mapper;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.izettle.java.ValueChecks;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class PagingFactory<R> {
+
+    private Session session;
+    private PagingResultMapper<R> mapper;
+    private int fetchSize = 100;
+
+    public PagingFactory(final Session session, final Function<Row, R> mapper) {
+        this.session = requireNonNull(session, "session must not be null");
+        this.mapper = new PagingResultMapper<>(mapper);
+    }
+
+    public PagingFactory(final Session session, final Function<Row, R> mapper, int fetchSize) {
+        ValueChecks.assertTrue(fetchSize > 0, "Fetch size must be at least 1");
+        requireNonNull(mapper, "mapper must not be null");
+        this.fetchSize = fetchSize;
+        this.session = requireNonNull(session, "session must not be null");
+        this.mapper = new PagingResultMapper<>(mapper);
+    }
+
+    public PagingFactory(final Session session, final Mapper<R> mapper) {
+        this.session = requireNonNull(session, "session must not be null");
+        requireNonNull(mapper, "mapper must not be null");
+        this.mapper = new PagingResultMapper<>(mapper);
+    }
+
+    public PagingResult<R> execute(Statement statement, PagingContext context) {
+        requireNonNull(statement, "statement must not be null");
+        requireNonNull(context, "context must not be null");
+        return new CassandraPaging(this, statement, context).execute();
+    }
+
+    public void execute(Statement statement, Consumer<List<R>> resultConsumer) {
+        execute(statement, resultConsumer, PagingContext.create(fetchSize));
+    }
+
+    public void execute(Statement statement, Consumer<List<R>> resultConsumer, int fetchSize) {
+        ValueChecks.assertTrue(fetchSize > 0, "Fetch size must be at least 1");
+        execute(statement, resultConsumer, PagingContext.create(fetchSize));
+    }
+
+    public void execute(Statement statement, Consumer<List<R>> resultConsumer, PagingContext context) {
+        requireNonNull(statement, "statement must not be null");
+        requireNonNull(resultConsumer, "resultConsumer must not be null");
+        requireNonNull(context, "context must not be null");
+
+        final CassandraPaging paging = new CassandraPaging(this, statement, context);
+        paging.iterate(resultConsumer);
+    }
+
+    public class CassandraPaging {
+
+        private final PagingFactory<R> factory;
+        private final Statement statement;
+        private PagingResult<R> result;
+
+        CassandraPaging(PagingFactory<R> factory, Statement statement, PagingContext data) {
+            this.statement = statement;
+            this.factory = factory;
+            result =
+                new PagingResult<>(Collections.emptyList(), data.getPagingState().orElse(null), data.getFetchSize());
+        }
+
+        private void iterate(Consumer<List<R>> resultConsumer) {
+
+            do {
+                execute();
+                resultConsumer.accept(result.getResults());
+            } while (result.getPagingState().isPresent());
+        }
+
+        private PagingResult<R> execute() {
+            statement.setFetchSize(result.getFetchSize());
+            result.getPagingState().map(PagingState::fromString).ifPresent(statement::setPagingState);
+            final List<R> results = new ArrayList<>();
+            final ResultSet resultSet = session.execute(statement);
+            final PagingState newPagingState = resultSet.getExecutionInfo().getPagingState();
+            final PagingIterable<?, R> pagingIterable = factory.mapper.map(resultSet);
+            final Iterator<R> iterator = pagingIterable.iterator();
+            while (results.size() < result.getFetchSize() && iterator.hasNext()) {
+                results.add(iterator.next());
+            }
+            final String pagingState = resultSet.isExhausted() ? null : newPagingState.toString();
+            this.result = result.withResult(results, pagingState);
+            return result;
+        }
+    }
+
+    class PagingResultMapper<R> {
+
+        private final Function<ResultSet, PagingIterable<?, R>> iterableFunction;
+
+        PagingResultMapper(final Function<Row, R> mapper) {
+            requireNonNull(mapper, "mapper must not be null");
+            this.iterableFunction = new ManualMapper<>(mapper)::map;
+        }
+
+        PagingResultMapper(final Mapper<R> mapper) {
+            this.iterableFunction = mapper::map;
+        }
+
+        public PagingIterable<?, R> map(ResultSet rs) {
+            return iterableFunction.apply(rs);
+        }
+
+        class ManualMapper<R> {
+
+            private final Function<Row, R> mapper;
+
+            private ManualMapper(final Function<Row, R> mapper) {
+                this.mapper = mapper;
+            }
+
+            private PagingIterable<?, R> map(ResultSet rs) {
+                return new ManualPagingIterable<>(rs, mapper);
+
+            }
+
+            public class ManualPagingIterable<R> implements PagingIterable<ManualPagingIterable<R>, R> {
+
+                private final ResultSet rs;
+                private final Function<Row, R> mapper;
+
+                ManualPagingIterable(final ResultSet rs, final Function<Row, R> mapper) {
+                    this.rs = rs;
+                    this.mapper = mapper;
+                }
+
+                @Override
+                public boolean isExhausted() {
+                    return rs.isExhausted();
+                }
+
+                @Override
+                public boolean isFullyFetched() {
+                    return rs.isFullyFetched();
+                }
+
+                @Override
+                public int getAvailableWithoutFetching() {
+                    return rs.getAvailableWithoutFetching();
+                }
+
+                @Override
+                public ListenableFuture<ManualPagingIterable<R>> fetchMoreResults() {
+                    return Futures.transform(rs.fetchMoreResults(), rs -> ManualMapper.ManualPagingIterable.this);
+                }
+
+                @Override
+                public R one() {
+                    return mapper.apply(rs.one());
+                }
+
+                @Override
+                public List<R> all() {
+                    return rs.all().stream().map(mapper).collect(Collectors.toList());
+                }
+
+                @Override
+                public Iterator<R> iterator() {
+                    return new Iterator<R>() {
+                        private final Iterator<Row> rowIterator = rs.iterator();
+
+                        @Override
+                        public boolean hasNext() {
+                            return rowIterator.hasNext();
+                        }
+
+                        @Override
+                        public R next() {
+                            return mapper.apply(rowIterator.next());
+                        }
+
+                        @Override
+                        public void remove() {
+                            throw new UnsupportedOperationException();
+                        }
+                    };
+                }
+
+                @Override
+                public ExecutionInfo getExecutionInfo() {
+                    return rs.getExecutionInfo();
+                }
+
+                @Override
+                public List<ExecutionInfo> getAllExecutionInfo() {
+                    return rs.getAllExecutionInfo();
+                }
+            }
+        }
+
+    }
+}

--- a/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingInput.java
+++ b/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingInput.java
@@ -1,0 +1,33 @@
+package com.izettle.cassandra.paging;
+
+import static java.util.Objects.requireNonNull;
+
+import com.izettle.java.ValueChecks;
+
+public interface PagingInput<D> {
+
+    int getFetchSize();
+
+    D getData();
+
+    static <D> PagingInput<D> createInput(D data, int fetchSize) {
+        requireNonNull(data, "data must not be null");
+        ValueChecks.assertTrue(fetchSize > 1, "FetchSize must at least 1");
+        return new PagingInput<D>() {
+            @Override
+            public int getFetchSize() {
+                return fetchSize;
+            }
+
+            @Override
+            public D getData() {
+                return data;
+            }
+        };
+    }
+
+    static PagingInput<Void> createVoidInput(int fetchSize) {
+        final Void v = null;
+        return createInput(v, fetchSize);
+    }
+}

--- a/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingResult.java
+++ b/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingResult.java
@@ -1,0 +1,33 @@
+package com.izettle.cassandra.paging;
+
+import java.util.List;
+import java.util.Optional;
+
+public class PagingResult<R> implements PagingContext {
+
+    private List<R> results;
+    private String pagingState;
+    private int fetchSize;
+
+    public PagingResult(final List<R> results, final String pagingState, final int fetchSize) {
+        this.results = results;
+        this.pagingState = pagingState;
+        this.fetchSize = fetchSize;
+    }
+
+    public int getFetchSize() {
+        return fetchSize;
+    }
+
+    public List<R> getResults() {
+        return results;
+    }
+
+    public Optional<String> getPagingState() {
+        return Optional.ofNullable(pagingState);
+    }
+
+    public PagingResult<R> withResult(final List<R> results, final String pagingState) {
+        return new PagingResult<>(results, pagingState, fetchSize);
+    }
+}

--- a/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingUrlBuilder.java
+++ b/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingUrlBuilder.java
@@ -1,0 +1,50 @@
+package com.izettle.cassandra.paging;
+
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+public class PagingUrlBuilder {
+
+    protected final String pageQueryName;
+    protected final UriInfo uriInfo;
+    protected final HttpServletResponse response;
+    protected final Map<String, String> queryParams = new HashMap<>();
+
+    public PagingUrlBuilder(final UriInfo uriInfo, final HttpServletResponse response) {
+        this.uriInfo = requireNonNull(uriInfo, "uriInfo must not be null");
+        this.response = requireNonNull(response, "response must not be null");
+        this.pageQueryName = "name";
+    }
+
+    public static PagingUrlBuilder create(UriInfo uriInfo, HttpServletResponse response) {
+        return new PagingUrlBuilder(uriInfo, response);
+    }
+
+    public PagingUrlBuilder queryParam(String name, Object value) {
+        queryParams.put(name, value.toString());
+        return this;
+    }
+
+    public void setLinkOnResponse() {
+        response.setHeader(LINK, createNextUrl());
+    }
+
+    public String createNextUrl() {
+        final UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
+        queryParams.forEach(uriBuilder::queryParam);
+        return "<" + uriBuilder + ">; rel=\"next\"";
+    }
+
+    public void setPageOnResponse(final PagingResult result) {
+        result.getPagingState().ifPresent(page -> {
+            final PagingUrlBuilder builder = PagingUrlBuilder.create(uriInfo, response);
+            builder.queryParam(builder.pageQueryName, page.toString()).setLinkOnResponse();
+        });
+    }
+}

--- a/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingUrlBuilder.java
+++ b/izettle-cassandra-datastax/src/main/java/com/izettle/cassandra/paging/PagingUrlBuilder.java
@@ -11,6 +11,8 @@ import javax.ws.rs.core.UriInfo;
 
 public class PagingUrlBuilder {
 
+    public static final String DEFAULT_PAGE_NAME = "page";
+
     protected final String pageQueryName;
     protected final UriInfo uriInfo;
     protected final HttpServletResponse response;
@@ -19,7 +21,7 @@ public class PagingUrlBuilder {
     public PagingUrlBuilder(final UriInfo uriInfo, final HttpServletResponse response) {
         this.uriInfo = requireNonNull(uriInfo, "uriInfo must not be null");
         this.response = requireNonNull(response, "response must not be null");
-        this.pageQueryName = "name";
+        this.pageQueryName = DEFAULT_PAGE_NAME;
     }
 
     public static PagingUrlBuilder create(UriInfo uriInfo, HttpServletResponse response) {
@@ -46,5 +48,13 @@ public class PagingUrlBuilder {
             final PagingUrlBuilder builder = PagingUrlBuilder.create(uriInfo, response);
             builder.queryParam(builder.pageQueryName, page.toString()).setLinkOnResponse();
         });
+    }
+
+    public static void setPageOnResponse(
+        final UriInfo uriInfo,
+        final HttpServletResponse response,
+        final PagingResult result
+    ) {
+        new PagingUrlBuilder(uriInfo, response).setPageOnResponse(result);
     }
 }

--- a/izettle-cassandra-datastax/src/test/java/com/izettle/cassandra/paging/Car.java
+++ b/izettle-cassandra-datastax/src/test/java/com/izettle/cassandra/paging/Car.java
@@ -1,0 +1,93 @@
+package com.izettle.cassandra.paging;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import com.izettle.java.UUIDFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
+@Table(name = "car", keyspace = "paging")
+public class Car {
+
+    @Column
+    @PartitionKey
+    private String owner;
+    @Column
+    @PartitionKey(1)
+    private UUID id;
+    @Column
+    private String brand;
+    @Column
+    private int year;
+
+    public static Car random(String owner) {
+        final Car car = new Car();
+        car.setOwner(owner);
+        car.setId(UUIDFactory.createUUID1());
+        car.setBrand(randomAlphabetic(5));
+        car.setYear(Integer.parseInt("19" + randomNumeric(2)));
+        return car;
+    }
+
+    public static List<Car> random(String owner, int number) {
+        final List<Car> cars = new ArrayList<>();
+        IntStream.range(0, number).forEach(value -> cars.add(Car.random(owner)));
+        return cars;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(final String owner) {
+        this.owner = owner;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public void setBrand(final String brand) {
+        this.brand = brand;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(final int year) {
+        this.year = year;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this);
+    }
+}

--- a/izettle-cassandra-datastax/src/test/java/com/izettle/cassandra/paging/CarAccessor.java
+++ b/izettle-cassandra-datastax/src/test/java/com/izettle/cassandra/paging/CarAccessor.java
@@ -1,0 +1,14 @@
+package com.izettle.cassandra.paging;
+
+import com.datastax.driver.mapping.Result;
+import com.datastax.driver.mapping.annotations.Accessor;
+import com.datastax.driver.mapping.annotations.Query;
+
+@Accessor
+@FunctionalInterface
+public interface CarAccessor {
+
+    @Query("SELECT * FROM paging.car where owner=?")
+    Result<Car> getAll(String owner);
+
+}

--- a/izettle-cassandra-datastax/src/test/java/com/izettle/cassandra/paging/PagingTest.java
+++ b/izettle-cassandra-datastax/src/test/java/com/izettle/cassandra/paging/PagingTest.java
@@ -1,0 +1,150 @@
+package com.izettle.cassandra.paging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.cassandraunit.utils.EmbeddedCassandraServerHelper.getSession;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.mapping.Mapper;
+import com.datastax.driver.mapping.MappingManager;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.thrift.transport.TTransportException;
+import org.assertj.core.api.Assertions;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class PagingTest {
+
+    private static MappingManager mappingManager;
+    private static Mapper<Car> mapper;
+    private static CarAccessor carAccessor;
+    private static PagingFactory<Car> pagingFactory;
+    private static Session session;
+
+    private Statement statement;
+    private String owner;
+
+    @BeforeClass
+    public static void beforeClass() throws InterruptedException, IOException, TTransportException {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+        session = getSession();
+
+        session.execute("CREATE KEYSPACE paging\n"
+            + "  WITH REPLICATION = {\n"
+            + "   'class' : 'SimpleStrategy',\n"
+            + "   'replication_factor' : 1\n"
+            + "  };");
+
+        session.execute("CREATE TABLE paging.car (\n"
+            + "  owner text,\n"
+            + "  id timeuuid,\n"
+            + "  brand text,\n"
+            + "  year int,\n"
+            + "  PRIMARY KEY (owner, id))\n"
+            + " WITH CLUSTERING ORDER BY (id DESC);");
+
+        mappingManager = new MappingManager(session);
+        mapper = mappingManager.mapper(Car.class);
+        carAccessor = mappingManager.createAccessor(CarAccessor.class);
+        pagingFactory = new PagingFactory<>(session, mapper);
+
+    }
+
+    @Before
+    public void before() {
+        session.execute("Truncate paging.car;").wasApplied();
+        owner = RandomStringUtils.randomAlphabetic(3);
+        statement = carAccessor.getAll(owner).getExecutionInfo().getStatement();
+    }
+
+    @Test
+    public void pageAllInOnePage() {
+        final int numberOfCars = 10;
+        final List<Car> expected = createCars(numberOfCars);
+        final int pageSize = numberOfCars + 1;
+
+        final PagingData<String> selectAll = new PagingData<>(owner, pageSize);
+        final PagingResult<Car> result = pagingFactory.execute(statement, selectAll);
+
+        assertThat(result.getResults()).containsAll(expected);
+        assertThat(result.getPagingState()).isEmpty();
+
+    }
+
+    @Test
+    public void pageExactResult() {
+
+        final int numberOfCars = 4;
+        final List<Car> expected = createCars(numberOfCars);
+
+        final PagingData<String> selectAll = new PagingData<>(owner, numberOfCars);
+        final PagingResult<Car> result = pagingFactory.execute(statement, selectAll);
+        assertThat(result.getResults()).hasSize(numberOfCars);
+        assertThat(result.getResults()).containsAll(expected);
+        assertThat(result.getPagingState()).isEmpty();
+    }
+
+    @Test
+    public void twoIteratorsExact() {
+        final int numberOfCars = 4;
+        final int pageSize = numberOfCars / 2;
+        final List<Car> expected = createCars(numberOfCars);
+
+        final PagingData<String> selectAll = new PagingData<>(owner, pageSize);
+        final PagingResult<Car> first = pagingFactory.execute(statement, selectAll);
+        final ArrayList<Car> cars = new ArrayList<>(first.getResults());
+        Assertions.assertThat(first.getResults()).hasSize(pageSize);
+        final PagingResult<Car> second = pagingFactory.execute(statement, first);
+        cars.addAll(second.getResults());
+        assertThat(cars).hasSize(numberOfCars);
+        assertThat(cars).containsAll(expected);
+        assertThat(second.getPagingState()).isEmpty();
+    }
+
+    @Test
+    public void twoIterations() {
+        final int numberOfCars = 9;
+        final int pageSize = 5;
+        final List<Car> expected = createCars(numberOfCars);
+
+        final PagingData<String> selectAll = new PagingData<>(owner, pageSize);
+        final PagingResult<Car> first = pagingFactory.execute(statement, selectAll);
+        final ArrayList<Car> cars = new ArrayList<>(first.getResults());
+        Assertions.assertThat(first.getResults()).hasSize(pageSize);
+        final PagingResult<Car> second = pagingFactory.execute(statement, first);
+        cars.addAll(second.getResults());
+
+        assertThat(second.getResults()).hasSize(4);
+        assertThat(cars).hasSize(numberOfCars);
+        assertThat(cars).containsAll(expected);
+        assertThat(second.getPagingState()).isEmpty();
+    }
+
+    @Test
+    public void testConsumeFunction() {
+        final int numberOfCars = 6;
+        final int pageSize = 2;
+        final List<Car> expected = createCars(numberOfCars);
+        final List<Car> actual = new ArrayList<>();
+
+        Consumer<List<Car>> resultConsumer = actual::addAll;
+
+        pagingFactory.execute(statement, resultConsumer, pageSize);
+
+        assertThat(actual).containsAll(expected);
+
+    }
+
+    private List<Car> createCars(int numberOfCars) {
+        final List<Car> cars = Car.random(owner, numberOfCars);
+        cars.forEach(mapper::save);
+        return cars;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
         <astyanax.version>3.9.0</astyanax.version>
         <aws.version>1.11.229</aws.version>
         <bouncycastle.version>1.58</bouncycastle.version>
-        <cassandra-driver.version>3.3.0</cassandra-driver.version>
-        <cassandra-unit.version>2.2.2.1</cassandra-unit.version>
+        <cassandra-driver.version>3.4.0</cassandra-driver.version>
+        <cassandra-unit.version>3.1.1.0</cassandra-unit.version>
         <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>23.0</guava.version>
         <jackson.version>2.9.2</jackson.version>
         <junit.version>4.12</junit.version>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>


### PR DESCRIPTION
Added Paging to be used for both Datastax mappers and manual mapping providing a Function that maps Row to an Java POJO.

There's two main usecases:

1) Paging responses for endpoints. PR also contain tool to set Link on response
2) Iterate over an statement and Consume result. GDRP upload for example.

https://izettle.atlassian.net/browse/SF-1713