### PR TITLE
Enforce that adminContextPath is set to /system

### DIFF
--- a/izettle-filters/README.md
+++ b/izettle-filters/README.md
@@ -2,8 +2,10 @@
 
 ## AdminDirectAccess
 
-Prevents non-direct access to admin resources in Dropwizard.
-That is, requests going via a load balancer.
+Configures Dropwizard to serve admin resources from `/system` and
+prevents non-direct access (that is, requests going via a load balancer)
+to said resources.
+
 
 ### Usage
 

--- a/izettle-filters/src/main/java/com/izettle/dropwizard/filters/AdminContextPathEnforcer.java
+++ b/izettle-filters/src/main/java/com/izettle/dropwizard/filters/AdminContextPathEnforcer.java
@@ -1,0 +1,38 @@
+package com.izettle.dropwizard.filters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class AdminContextPathEnforcer implements ConfigurationSourceProvider {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+    private final ConfigurationSourceProvider wrappedProvider;
+
+    public AdminContextPathEnforcer(ConfigurationSourceProvider wrappedProvider) {
+        this.wrappedProvider = wrappedProvider;
+    }
+
+    @Override
+    public InputStream open(String path) throws IOException {
+        JsonNode config = objectMapper.readTree(wrappedProvider.open(path));
+
+        enforceAdminContextPath(config);
+
+        return new ByteArrayInputStream(objectMapper.writeValueAsBytes(config));
+    }
+
+    static void enforceAdminContextPath(final JsonNode config) {
+        String adminContextPath = config.at("/server/adminContextPath").textValue();
+        if (adminContextPath != null && !adminContextPath.equals("/system")) {
+            throw new RuntimeException("Conflict when enforcing that adminContextPath is set to '/system': "
+                + "adminContextPath must be either undefined or set explicitly to /system");
+        }
+        ((ObjectNode) config.at("/server")).put("adminContextPath", "/system");
+    }
+}

--- a/izettle-filters/src/main/java/com/izettle/dropwizard/filters/AdminDirectAccessBundle.java
+++ b/izettle-filters/src/main/java/com/izettle/dropwizard/filters/AdminDirectAccessBundle.java
@@ -12,6 +12,9 @@ public class AdminDirectAccessBundle implements Bundle {
 
     @Override
     public void initialize(Bootstrap<?> bootstrap) {
+        bootstrap.setConfigurationSourceProvider(
+            new AdminContextPathEnforcer(bootstrap.getConfigurationSourceProvider())
+        );
     }
 
     @Override

--- a/izettle-filters/src/test/java/com/izettle/dropwizard/filters/AdminContextPathEnforcerTest.java
+++ b/izettle-filters/src/test/java/com/izettle/dropwizard/filters/AdminContextPathEnforcerTest.java
@@ -1,0 +1,44 @@
+package com.izettle.dropwizard.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.Test;
+
+public class AdminContextPathEnforcerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+    @Test
+    public void shouldNotChangeCorrectConfiguration() throws Exception {
+
+        JsonNode config = objectMapper.readTree("server:\n  adminContextPath: /system");
+        JsonNode originalConfig = config.deepCopy();
+
+        AdminContextPathEnforcer.enforceAdminContextPath(config);
+
+        assertThat(config)
+            .isEqualTo(originalConfig);
+    }
+
+    @Test
+    public void shouldSetAdminContextPathWhenUndefined() throws Exception {
+
+        JsonNode config = objectMapper.readTree("server:\n  foo: bar");
+
+        AdminContextPathEnforcer.enforceAdminContextPath(config);
+
+        assertThat(config)
+            .isEqualTo(objectMapper.readTree("server:\n  foo: bar\n  adminContextPath: /system"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldThrowOnIncorrectConfiguration() throws Exception {
+
+        JsonNode config = objectMapper.readTree("server:\n  adminContextPath: /not-system");
+
+        AdminContextPathEnforcer.enforceAdminContextPath(config);
+    }
+}


### PR DESCRIPTION
 - If set to /system: Do nothing
 - If set to something else: Throw
 - If not set at all: Set it to /system

This removes the need for any config changes for services --
all they need is the bundle. This is an enabler towards having
an iZettle Dropwizard flavor, with all necessary config,
that works OOTB.