### PR TITLE
Bump to basepom 1.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>izettle</artifactId>
-        <version>1.25</version>
+        <version>1.26</version>
     </parent>
 
     <groupId>com.izettle.toolbox</groupId>


### PR DESCRIPTION
Accidentally merged with bad basepom 1.25 (which has broken spotbugs support)